### PR TITLE
Support React Native headers both in the React namespace

### DIFF
--- a/ios/RCTPdf.xcodeproj/project.pbxproj
+++ b/ios/RCTPdf.xcodeproj/project.pbxproj
@@ -230,9 +230,10 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../React/**",
-					"$(SRCROOT)/../react-native/React/**",
-					"$(SRCROOT)/node_modules/react-native/React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -246,9 +247,10 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../React/**",
-					"$(SRCROOT)/../react-native/React/**",
-					"$(SRCROOT)/node_modules/react-native/React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/RCTPdf/RCTPdfView.h
+++ b/ios/RCTPdf/RCTPdfView.h
@@ -6,8 +6,13 @@
 //  Copyright (c) wonday.org All rights reserved.
 //
 
+#if __has_include(<React/RCTAssert.h>)
 #import <React/RCTEventDispatcher.h>
 #import <React/UIView+React.h>
+#else
+#import "RCTEventDispatcher.h"
+#import "UIView+React.h"
+#endif
 
 
 @class RCTEventDispatcher;

--- a/ios/RCTPdf/RCTPdfView.m
+++ b/ios/RCTPdf/RCTPdfView.m
@@ -8,14 +8,20 @@
 
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
+#import "RCTPdfView.h"
+#import "WPdfView.h"
+
+#if __has_include(<React/RCTAssert.h>)
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/UIView+React.h>
 #import <React/RCTLog.h>
-
-
-#import "RCTPdfView.h"
-#import "WPdfView.h"
+#else
+#import "RCTBridgeModule.h"
+#import "RCTEventDispatcher.h"
+#import "UIView+React.h"
+#import "RCTLog.h"
+#endif
 
 @implementation RCTPdfView {
 

--- a/ios/RCTPdf/RCTPdfViewManager.h
+++ b/ios/RCTPdf/RCTPdfViewManager.h
@@ -6,7 +6,12 @@
 //  Copyright (c) wonday.org All rights reserved.
 //
 
+#if __has_include(<React/RCTAssert.h>)
 #import <React/RCTViewManager.h>
+#else
+#import "RCTViewManager.h"
+#endif
+
 
 @interface RCTPdfViewManager : RCTViewManager
 

--- a/ios/RCTPdf/RCTPdfViewManager.m
+++ b/ios/RCTPdf/RCTPdfViewManager.m
@@ -5,12 +5,18 @@
 //  Created by Wonday on 17/4/21.
 //  Copyright (c) wonday.org All rights reserved.
 //
-
 #import <Foundation/Foundation.h>
-#import <React/RCTBridge.h>
+
 #import "RCTPdfViewManager.h"
 #import "RCTPdfView.h"
+
+#if __has_include(<React/RCTAssert.h>)
 #import <React/RCTEventDispatcher.h>
+#import <React/RCTBridge.h>
+#else
+#import "RCTBridge.h"
+#import "RCTEventDispatcher.h"
+#endif
 
 @implementation RCTPdfViewManager
 

--- a/ios/RCTPdf/WPdfView.h
+++ b/ios/RCTPdf/WPdfView.h
@@ -6,8 +6,13 @@
 //  Copyright (c) wonday.org All rights reserved.
 //
 
+#if __has_include(<React/RCTAssert.h>)
 #import <React/RCTEventDispatcher.h>
 #import <React/UIView+React.h>
+#else
+#import "RCTEventDispatcher.h"
+#import "UIView+React.h"
+#endif
 
 
 @class RCTEventDispatcher;

--- a/ios/RCTPdf/WPdfView.m
+++ b/ios/RCTPdf/WPdfView.m
@@ -8,13 +8,19 @@
 
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
+#import "WPdfView.h"
+
+#if __has_include(<React/RCTAssert.h>)
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/UIView+React.h>
 #import <React/RCTLog.h>
-
-
-#import "WPdfView.h"
+#else
+#import "RCTBridgeModule.h"
+#import "RCTEventDispatcher.h"
+#import "UIView+React.h"
+#import "RCTLog.h"
+#endif
 
 @implementation WPdfView
 {


### PR DESCRIPTION
To fix this and maintain backwards compatibility with RN <= 0.39 without having to branch you can also change your includes like below, using #if __has_include. That's what we did for our React Native libraries and it worked well.

```
// Support React Native headers both in the React namespace, where they are in RN version 0.40+,
// and no namespace, for older versions of React Native
#if __has_include(<React/RCTBridge.h>)
#import <React/RCTBridge.h>
#else
#import "RCTBridge.h"
#endif
```
from [react-native-fetch-blob/issues/244](https://github.com/wkh237/react-native-fetch-blob/issues/244)