### PR TITLE
Fix old props state

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ export default class Pdf extends Component {
     componentWillReceiveProps(nextProps) {
         if (nextProps.source != this.props.source) {
             __DEV__ && console.log("componentWillReceiveProps: source changed");
-            this._loadFromSource();
+            this._loadFromSource(nextProps.source);
         }
     }
 
@@ -41,9 +41,9 @@ export default class Pdf extends Component {
         this._loadFromSource();
     }
 
-    _loadFromSource = () => {
+    _loadFromSource = (nextProps) => {
 
-        const source = resolveAssetSource(this.props.source) || {};
+        const source = resolveAssetSource(nextProps || this.props.source) || {};
         __DEV__ && console.log("PDF source:");
         __DEV__ && console.log(source);
 


### PR DESCRIPTION
I had the problem that i try to load multiple documents from a ListView everytime i press on an item and the PDF view won't update.

The problem is that you never use the new props but always the initial props.

This is my quick fix for the problem. You could do a setState inside the componentWillReceiveProps method which is cleaner i think. But you have to decide.