### PR TITLE
Fix for TypeScript definitions (onLoadComplete and onPageChanged)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,8 +18,8 @@ interface Props {
   spacing?: number,
   password?: string,
   activityIndicator?: any,
-  onLoadComplete?: () => void,
-  onPageChanged?: () => void,
+  onLoadComplete?: (pageCount: number) => void,
+  onPageChanged?: (page: number, pageCount: number) => void,
   onError?: ()=> void,
 }
 


### PR DESCRIPTION
`onLoadComplete` callback takes `pageCount` as parameter. 
`onPageChanged` callback takes `page` and `pageCount` as parameters.