### PR TITLE
Replace PropTypes with prop-types package

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,237 +6,256 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
-import React,{ Component, PropTypes } from 'react';
+'use strict'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import {
-    ActivityIndicator,
-    requireNativeComponent,
-    View,
-    Platform,
-    ProgressBarAndroid,
-    ProgressViewIOS
-} from 'react-native';
+  ActivityIndicator,
+  requireNativeComponent,
+  View,
+  Platform,
+  ProgressBarAndroid,
+  ProgressViewIOS,
+} from 'react-native'
 import RNFetchBlob from 'react-native-fetch-blob'
-const SHA1 = require("crypto-js/sha1");
-import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
+const SHA1 = require('crypto-js/sha1')
+import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource'
 
 export default class Pdf extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            path: "",
-            isDownloaded: false,
-            progress: 0,
-        };
-
-        this.uri = "";
-        this.lastRNBFTask = null;
-
+  constructor(props) {
+    super(props)
+    this.state = {
+      path: '',
+      isDownloaded: false,
+      progress: 0,
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.source != this.props.source) {
-            //__DEV__ && console.log("componentWillReceiveProps: source changed");
-            this._loadFromSource(nextProps.source);
-        }
+    this.uri = ''
+    this.lastRNBFTask = null
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.source != this.props.source) {
+      //__DEV__ && console.log("componentWillReceiveProps: source changed");
+      this._loadFromSource(nextProps.source)
+    }
+  }
+
+  componentDidMount() {
+    this._loadFromSource(this.props.source)
+  }
+
+  _loadFromSource = newSource => {
+    const source = resolveAssetSource(newSource) || {}
+    //__DEV__ && console.log("PDF source:");
+    //__DEV__ && console.log(source);
+
+    let uri = source.uri || ''
+
+    // no chanage then return
+    if (this.uri == uri) return
+    this.uri = uri
+
+    // first set to initial state
+    this.setState({ isDownloaded: false, path: '', progress: 0 })
+
+    const cacheFile = RNFetchBlob.fs.dirs.CacheDir + '/' + SHA1(uri) + '.pdf'
+
+    if (source.cache) {
+      RNFetchBlob.fs
+        .exists(cacheFile)
+        .then(exist => {
+          if (exist) {
+            this.setState({ path: cacheFile, isDownloaded: true })
+          } else {
+            // cache not exist then re load it
+            this._prepareFile(source)
+          }
+        })
+        .catch(() => {
+          this._prepareFile(source)
+        })
+    } else {
+      this._prepareFile(source)
+    }
+  }
+
+  _prepareFile = source => {
+    if (source.uri) {
+      let uri = source.uri || ''
+
+      const isNetwork = !!(uri && uri.match(/^https?:\/\//))
+      const isAsset = !!(uri && uri.match(/^bundle-assets:\/\//))
+      const isBase64 = !!(uri && uri.match(/^data:application\/pdf;base64/))
+
+      const cacheFile = RNFetchBlob.fs.dirs.CacheDir + '/' + SHA1(uri) + '.pdf'
+
+      // delete old cache file
+      RNFetchBlob.fs.unlink(cacheFile)
+
+      if (isNetwork) {
+        this._downloadFile(source, cacheFile)
+      } else if (isAsset) {
+        RNFetchBlob.fs
+          .cp(uri, cacheFile)
+          .then(() => {
+            //__DEV__ && console.log("load from asset:"+uri);
+            this.setState({ path: cacheFile, isDownloaded: true })
+          })
+          .catch(error => {
+            RNFetchBlob.fs.unlink(cacheFile)
+            console.warn('load from asset error')
+            console.log(error)
+            this.props.onError && this.props.onError('load pdf failed.')
+          })
+      } else if (isBase64) {
+        let data = uri.replace(/data:application\/pdf;base64\,/i, '')
+        RNFetchBlob.fs
+          .writeFile(cacheFile, data, 'base64')
+          // listen to download progress event
+          .progress((received, total) => {
+            //__DEV__ && console.log('progress', received / total);
+            this.props.onLoadProgress &&
+              this.props.onLoadProgress(received / total)
+            this.setState({ progress: received / total })
+          })
+          .then(() => {
+            //__DEV__ && console.log("write base64 to file:" + cacheFile);
+            this.setState({ path: cacheFile, isDownloaded: true })
+          })
+          .catch(() => {
+            RNFetchBlob.fs.unlink(this.path)
+            console.warn('write base64 file error!')
+            this.props.onError && this.props.onError('load pdf failed.')
+          })
+      } else {
+        //__DEV__ && console.log("default source type as file");
+        this.setState({
+          path: uri.replace(/file:\/\//i, ''),
+          isDownloaded: true,
+        })
+      }
+    } else {
+      console.error('no pdf source!')
+    }
+  }
+
+  _downloadFile = (source, cacheFile) => {
+    if (this.lastRNBFTask != null) {
+      this.lastRNBFTask.cancel(err => {
+        //__DEV__ && console.log("Load pdf from url was cancelled.");
+      })
     }
 
-    componentDidMount() {
-        this._loadFromSource(this.props.source);
+    this.lastRNBFTask = RNFetchBlob.config({
+      // response data will be saved to this path if it has access right.
+      path: cacheFile,
+    })
+      .fetch(
+        source.method ? source.method : 'GET',
+        source.uri,
+        source.headers ? source.headers : {}
+      )
+      // listen to download progress event
+      .progress((received, total) => {
+        //__DEV__ && console.log('progress', received / total);
+        this.props.onLoadProgress && this.props.onLoadProgress(received / total)
+        this.setState({ progress: received / total })
+      })
+
+    this.lastRNBFTask
+      .then(res => {
+        //__DEV__ && console.log('Load pdf from url and saved to ', res.path())
+        this.lastRNBFTask = null
+        this.setState({ path: cacheFile, isDownloaded: true, progress: 1 })
+      })
+      .catch(error => {
+        console.warn(`download ${source.uri} error.`)
+        console.log(error)
+        this.lastRNBFTask = null
+        RNFetchBlob.fs.unlink(cacheFile)
+        this.props.onError && this.props.onError('load pdf failed.')
+      })
+  }
+
+  setNativeProps = nativeProps => {
+    this._root.setNativeProps(nativeProps)
+  }
+
+  _onChange = (event) => {
+    let message = event.nativeEvent.message.split('|')
+    //__DEV__ && console.log("onChange: " + message);
+    if (message.length > 0) {
+      if (message[0] == 'loadComplete') {
+        this.props.onLoadComplete &&
+          this.props.onLoadComplete(Number(message[1]))
+      } else if (message[0] == 'pageChanged') {
+        this.props.onPageChanged &&
+          this.props.onPageChanged(Number(message[1]), Number(message[2]))
+      } else if (message[0] == 'error') {
+        this.props.onError && this.props.onError(message[1])
+      }
     }
+  }
 
-    _loadFromSource = (newSource) => {
-
-        const source = resolveAssetSource(newSource) || {};
-        //__DEV__ && console.log("PDF source:");
-        //__DEV__ && console.log(source);
-
-        let uri = source.uri || '';
-
-        // no chanage then return
-        if (this.uri == uri) return;
-        this.uri = uri;
-
-        // first set to initial state
-        this.setState({isDownloaded:false,path:"",progress:0});
-
-        const cacheFile = RNFetchBlob.fs.dirs.CacheDir + "/" + SHA1(uri) + ".pdf";
-
-        if (source.cache) {
-            RNFetchBlob.fs.exists(cacheFile)
-                .then((exist) => {
-                    if (exist) {
-                        this.setState({path:cacheFile, isDownloaded:true});
-                    } else {
-                        // cache not exist then re load it
-                        this._prepareFile(source);
-                    }
-                })
-                .catch(() => {
-                    this._prepareFile(source);
-                });
-        } else {
-            this._prepareFile(source);
-        }
+  render() {
+    if (!this.state.isDownloaded) {
+      return (
+        <View
+          style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}
+        >
+          {this.props.activityIndicator
+            ? this.props.activityIndicator
+            : Platform.OS == 'android'
+              ? <ProgressBarAndroid
+                  progress={this.state.progress}
+                  indeterminate={false}
+                  styleAttr="Horizontal"
+                  style={{ width: 200, height: 2 }}
+                />
+              : <ProgressViewIOS
+                  progress={this.state.progress}
+                  style={{ width: 200, height: 2 }}
+                />}
+        </View>
+      )
+    } else {
+      return (
+        <PdfCustom
+          ref={component => (this._root = component)}
+          {...this.props}
+          style={[{ backgroundColor: '#EEE' }, this.props.style]}
+          path={this.state.path}
+          onChange={this._onChange}
+        />
+      )
     }
-
-    _prepareFile = (source) => {
-
-        if (source.uri) {
-
-            let uri = source.uri || '';
-
-            const isNetwork = !!(uri && uri.match(/^https?:\/\//));
-            const isAsset = !!(uri && uri.match(/^bundle-assets:\/\//));
-            const isBase64 = !!(uri && uri.match(/^data:application\/pdf;base64/));
-
-            const cacheFile = RNFetchBlob.fs.dirs.CacheDir + "/" + SHA1(uri) + ".pdf";
-
-            // delete old cache file
-            RNFetchBlob.fs.unlink(cacheFile);
-
-
-            if (isNetwork) {
-                this._downloadFile(source, cacheFile);
-            } else if (isAsset) {
-                RNFetchBlob.fs.cp(uri, cacheFile)
-                    .then(() => {
-                        //__DEV__ && console.log("load from asset:"+uri);
-                        this.setState({path:cacheFile, isDownloaded:true});
-                    })
-                    .catch((error) => {
-                        RNFetchBlob.fs.unlink(cacheFile);
-                        console.warn("load from asset error");
-                        console.log(error);
-                        this.props.onError && this.props.onError("load pdf failed.");
-                    });
-            } else if (isBase64) {
-                let data = uri.replace(/data:application\/pdf;base64\,/i,"");
-                RNFetchBlob.fs.writeFile(cacheFile, data, 'base64')
-                    // listen to download progress event
-                    .progress((received, total) => {
-                        //__DEV__ && console.log('progress', received / total);
-                        this.props.onLoadProgress && this.props.onLoadProgress(received/total);
-                        this.setState({progress:received/total});
-                    })
-                    .then(()=>{
-                        //__DEV__ && console.log("write base64 to file:" + cacheFile);
-                        this.setState({path:cacheFile, isDownloaded:true});
-                    })
-                    .catch(() => {
-                        RNFetchBlob.fs.unlink(this.path);
-                        console.warn("write base64 file error!");
-                        this.props.onError && this.props.onError("load pdf failed.");
-                    });
-            } else {
-                //__DEV__ && console.log("default source type as file");
-                this.setState({path:uri.replace(/file:\/\//i,""),isDownloaded: true});
-            }
-        } else {
-            console.error("no pdf source!");
-        }
-
-    }
-
-    _downloadFile = (source, cacheFile) => {
-
-        if (this.lastRNBFTask!=null) {
-            this.lastRNBFTask.cancel((err) => {
-                //__DEV__ && console.log("Load pdf from url was cancelled.");
-            });
-        }
-
-        this.lastRNBFTask = RNFetchBlob
-            .config({
-                // response data will be saved to this path if it has access right.
-                path: cacheFile
-            })
-            .fetch(source.method?source.method:'GET', source.uri, source.headers?source.headers:{})
-            // listen to download progress event
-            .progress((received, total) => {
-                //__DEV__ && console.log('progress', received / total);
-                this.props.onLoadProgress && this.props.onLoadProgress(received/total);
-                this.setState({progress:received/total});
-            });
-
-        this.lastRNBFTask.then((res) => {
-                //__DEV__ && console.log('Load pdf from url and saved to ', res.path())
-                this.lastRNBFTask = null;
-                this.setState({path:cacheFile, isDownloaded:true, progress:1});
-            })
-            .catch((error)=>{
-                console.warn(`download ${source.uri} error.`);
-                console.log(error);
-                this.lastRNBFTask = null;
-                RNFetchBlob.fs.unlink(cacheFile);
-                this.props.onError && this.props.onError("load pdf failed.");
-            });
-    };
-
-    setNativeProps = (nativeProps) => {
-        this._root.setNativeProps(nativeProps);
-    };
-
-    _onChange = (event:Event) => {
-        let message = event.nativeEvent.message.split("|");
-        //__DEV__ && console.log("onChange: " + message);
-        if (message.length>0){
-            if (message[0]=="loadComplete") {
-                this.props.onLoadComplete && this.props.onLoadComplete(Number(message[1]));
-            } else if (message[0]=="pageChanged") {
-                this.props.onPageChanged && this.props.onPageChanged(Number(message[1]),Number(message[2]));
-            } else if (message[0]=="error") {
-                this.props.onError && this.props.onError(message[1]);
-            }
-        }
-
-    };
-
-    render() {
-        if (!this.state.isDownloaded) {
-            return (
-                <View style={{flex:1,justifyContent: 'center',alignItems: 'center'}}>
-                    {this.props.activityIndicator
-                        ?this.props.activityIndicator
-                        :(Platform.OS == 'android'
-                            ?<ProgressBarAndroid progress={this.state.progress} indeterminate={false} styleAttr="Horizontal" style={{width:200, height:2}} />
-                            :<ProgressViewIOS progress={this.state.progress} style={{width:200, height:2}} />)
-                    }
-                </View>
-            );
-        } else {
-            return (
-                <PdfCustom ref={component => this._root = component} {...this.props} style={[{backgroundColor:"#EEE"},this.props.style]}  path={this.state.path} onChange={this._onChange}/>
-            )
-        }
-
-    }
-
+  }
 }
 
 Pdf.propTypes = {
-    ...View.propTypes,
-    path: PropTypes.string,
-    source: PropTypes.oneOfType([
-        PropTypes.shape({
-            uri: PropTypes.string,
-            cache: PropTypes.bool
-        }),
-        // Opaque type returned by require('./test.pdf')
-        PropTypes.number
-    ]).isRequired,
-    page: PropTypes.number,
-    scale: PropTypes.number,
-    horizontal: PropTypes.bool,
-    spacing: PropTypes.number,
-    password: PropTypes.string,
-    activityIndicator: PropTypes.any,
-    onChange: PropTypes.func,
-    onLoadComplete: PropTypes.func,
-    onPageChanged: PropTypes.func,
-    onError: PropTypes.func
-};
+  ...View.propTypes,
+  path: PropTypes.string,
+  source: PropTypes.oneOfType([
+    PropTypes.shape({
+      uri: PropTypes.string,
+      cache: PropTypes.bool,
+    }),
+    // Opaque type returned by require('./test.pdf')
+    PropTypes.number,
+  ]).isRequired,
+  page: PropTypes.number,
+  scale: PropTypes.number,
+  horizontal: PropTypes.bool,
+  spacing: PropTypes.number,
+  password: PropTypes.string,
+  activityIndicator: PropTypes.any,
+  onChange: PropTypes.func,
+  onLoadComplete: PropTypes.func,
+  onPageChanged: PropTypes.func,
+  onError: PropTypes.func,
+}
 
 var PdfCustom = requireNativeComponent('RCTPdf', Pdf, {
-    nativeOnly: {path:true, onChange: true}
-});
+  nativeOnly: { path: true, onChange: true },
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,157 @@
+{
+    "name": "react-native-pdf",
+    "version": "1.2.3",
+    "lockfileVersion": 1,
+    "dependencies": {
+        "asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "base-64": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+            "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
+        },
+        "brace-expansion": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "core-js": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+            "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        },
+        "crypto-js": {
+            "version": "3.1.9-1",
+            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+            "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+        },
+        "encoding": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
+        },
+        "fbjs": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+            "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+        },
+        "iconv-lite": {
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+            "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "isomorphic-fetch": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+            "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
+        },
+        "js-tokens": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+        },
+        "loose-envify": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+            "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+        },
+        "node-fetch": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+            "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ=="
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "promise": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+            "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
+        },
+        "prop-types": {
+            "version": "15.5.10",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+            "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ="
+        },
+        "react-native-fetch-blob": {
+            "version": "0.10.6",
+            "resolved": "https://registry.npmjs.org/react-native-fetch-blob/-/react-native-fetch-blob-0.10.6.tgz",
+            "integrity": "sha1-oAnJm79PNoHsyZHSU5hojcOPk/w="
+        },
+        "setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+        },
+        "ua-parser-js": {
+            "version": "0.7.13",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.13.tgz",
+            "integrity": "sha1-zZ3S+GSTs/RNvu7zeA/adMXuFL4="
+        },
+        "whatwg-fetch": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+            "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
         "url": "https://github.com/wonday/react-native-pdf/issues"
     },
     "dependencies": {
-        "react-native-fetch-blob": "^0.10.5",
-        "crypto-js": "^3.1.9-1"
+        "crypto-js": "^3.1.9-1",
+        "prop-types": "^15.5.10",
+        "react-native-fetch-blob": "^0.10.5"
     },
-    "peerDependencies": {
-    }
+    "peerDependencies": {}
 }


### PR DESCRIPTION
PropTypes was removed react in v15.5 and moved into it's own package. https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes

This PR implements that change so the warning no longer shows while developing. 

If you're wondering, the package-lock is a new standard which released in npm5 which makes installs much faster.

Also formatted the code a bit :P 