### PR TITLE
Remove deprecated android override for RN 0.47.0 compatibility

### DIFF
--- a/android/src/main/java/org/wonday/pdf/RCTPdfView.java
+++ b/android/src/main/java/org/wonday/pdf/RCTPdfView.java
@@ -26,7 +26,7 @@ public class RCTPdfView implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
+    // Deprecated as of RN 0.47.0
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
This PR makes this package compatible with RN 0.47.0 (see [this commit](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8)).