### PR TITLE
Fix TypeScript definition for onError

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 //
 //  react-native-pdf
-//  
+//
 //
 //  Created by Wonday on 17/4/21.
 //  Copyright (c) wonday.org All rights reserved.
@@ -22,7 +22,7 @@ interface Props {
   fitWidth?: boolean,
   onLoadComplete?: (pageCount: number) => void,
   onPageChanged?: (page: number, pageCount: number) => void,
-  onError?: ()=> void,
+  onError?: (error: string) => void,
 }
 
 declare class Pdf extends React.Component<Props, any> {}


### PR DESCRIPTION
The callback `onError` takes one parameter of type `string` (see README example code).