### PR TITLE
Readme hotfix: Changed the installation order at the guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ We use [`react-native-fetch-blob`](https://github.com/wkh237/react-native-fetch-
 So you should install react-native-pdf and react-native-fetch-blob
 
 ```bash
-npm install react-native-pdf --save
 npm install react-native-fetch-blob --save
+npm install react-native-pdf --save
 
-react-native link react-native-pdf
 react-native link react-native-fetch-blob
+react-native link react-native-pdf
 ```
 
 ### FAQ


### PR DESCRIPTION
Trying to install react-native-pdf as shown in the guide was throwing an UNMET_PEER_DEPENDENCY error.

The solution is simple, it will just work installing react-native-fetch-blob before react-native-pdf
I have just changed it on the README.md