### PR TITLE
[Android] Crashed because of missing props

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,16 @@ export default class Pdf extends Component {
         onError: PropTypes.func,
         onPageSingleTap: PropTypes.func,
         onScaleChanged: PropTypes.func,
-    };
+
+        // Props that are not available in the earlier react native version, added to prevent crashed on android
+        accessibilityLabel: PropTypes.string,
+        importantForAccessibility: PropTypes.string,
+        renderToHardwareTextureAndroid: PropTypes.string,
+        testID: PropTypes.string,
+        onLayout: PropTypes.bool,
+        accessibilityLiveRegion: PropTypes.string,
+        accessibilityComponentType: PropTypes.string,
+		};
 
     static defaultProps = {
         password: "",


### PR DESCRIPTION
Solved this problem: 
`When running, it shows 'Pdf' has no propType for native prop RCTPdf.acessibilityLabel of native type 'String'`.

Add missing props to prevent crash on earlier react native version, there's no need to update to react-native@0.47 but still need to have FlatList