### PR TITLE
Using pure component to render pdf pages

### DIFF
--- a/PdfPageView.js
+++ b/PdfPageView.js
@@ -32,8 +32,15 @@ export default class PdfPageView extends PureComponent {
     };
 
     render() {
+        const {
+            style,
+            ...restProps
+        } = this.props;
         return (
-            <PdfPageViewCustom {...this.props} style={[style, this._getStylePropsProps()]} />
+            <PdfPageViewCustom
+              {...restProps}
+              style={[style, this._getStylePropsProps()]}
+            />
         );
 
     }

--- a/PdfPageView.js
+++ b/PdfPageView.js
@@ -6,25 +6,34 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+
 'use strict';
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
     ViewPropTypes,
     requireNativeComponent,
 } from 'react-native';
+import {style} from "./index";
 
-export default class PdfPageView extends Component {
+export default class PdfPageView extends PureComponent {
 
     constructor(props) {
         super(props);
         this.state = {}
     }
 
-    render() {
+    _getStylePropsProps = () => {
+        const { width, height } = this.props;
+        if( width || height ) {
+            return { width, height };
+        }
+        return {};
+    };
 
+    render() {
         return (
-            <PdfPageViewCustom {...this.props} />
+            <PdfPageViewCustom {...this.props} style={[style, this._getStylePropsProps()]} />
         );
 
     }
@@ -33,7 +42,13 @@ export default class PdfPageView extends Component {
 PdfPageView.propTypes = {
     ...ViewPropTypes,
     fileNo: PropTypes.number,
-    page: PropTypes.number
+    page: PropTypes.number,
+    width: PropTypes.number,
+    height: PropTypes.number
+};
+
+PdfPageView.defaultProps = {
+    style: {}
 };
 
 let PdfPageViewCustom = requireNativeComponent('RCTPdfPageView', PdfPageView, {nativeOnly: {}});

--- a/PdfView.js
+++ b/PdfView.js
@@ -220,7 +220,8 @@ export default class PdfView extends Component {
                     key={item.id}
                     fileNo={this.state.fileNo}
                     page={item.key + 1}
-                    style={{width: this._getPageWidth(), height: this._getPageHeight()}}
+                    width={this._getPageWidth()}
+                    height={this._getPageHeight()}
                 />
                 {(index !== this.state.numberOfPages - 1) && this._renderSeparator()}
             </DoubleTapView>


### PR DESCRIPTION
PdfPageView act as item component in FlatList and it rendered too many times, like when you scroll, zoom, etc ...
Turn it into PureComponent to remove wasted render.