### PR TITLE
Add requiresMainQueueSetup to cure RN v0.52 warning

### DIFF
--- a/ios/RCTPdf/PdfManager.m
+++ b/ios/RCTPdf/PdfManager.m
@@ -105,6 +105,12 @@ RCT_EXPORT_METHOD(loadFile:(NSString *)path
     
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
+
 - (void)dealloc
 {
     // release pdf docs


### PR DESCRIPTION
RN 0.52 warning that, because PDFManager overrides 'init', it requires main queue setup, but does not implement 'requiresMainQueueSetup.' This PR implements 'requiresMainQueueSetup' and fixes the warning. 