### PR TITLE
Fix unhandled promise rejection when cached file already exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -268,12 +268,11 @@ export default class Pdf extends Component {
                     case 204: /* No content */
                     case 304: /* Not modified */
                     {
-                        RNFetchBlob.fs
-                            .mv(tempCacheFile,cacheFile)
-                            .then(() => {
-                                //__DEV__ && console.log("load from asset:"+uri);
-                                this.setState({ path: cacheFile, isDownloaded: true, progress: 1 });
-                            });
+                      RNFetchBlob.fs.unlink(cacheFile)
+                          .then(() => RNFetchBlob.fs
+                              .mv(tempCacheFile,cacheFile))
+                          .then(() => this.setState({ path: cacheFile, isDownloaded: true, progress: 1 }))
+                          .catch(this._onError);
                         break;
                     }
                     default:


### PR DESCRIPTION
Handle promise rejection when cached file already exists after a succesful fetch.

Pass the error object to the onError handler.