### PR TITLE
Use 'body' parameter of source if exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,8 @@ export default class Pdf extends Component {
             .fetch(
             source.method ? source.method : 'GET',
             source.uri,
-            source.headers ? source.headers : {}
+            source.headers ? source.headers : {},		
+            source.body ? source.body : ""
             )
             // listen to download progress event
             .progress((received, total) => {


### PR DESCRIPTION
It is used for POST requests that need a body parameter to load data from a server.