### PR TITLE
Do not count a scrolling gesture as a tap

### DIFF
--- a/DoubleTapView.js
+++ b/DoubleTapView.js
@@ -98,12 +98,14 @@ export default class DoubleTapView extends Component {
 
             }
         } else {
+            // do not count scroll gestures as taps
+            if (this.distance(0, gestureState.dx, 0, gestureState.dy) < 10) {
 
-            this.timer = setTimeout(() => {
-                this.props.onSingleTap();
-                this.timer = null;
-            }, this.props.delay);
-
+                this.timer = setTimeout(() => {
+                    this.props.onSingleTap();
+                    this.timer = null;
+                }, this.props.delay);
+            }
         }
 
 


### PR DESCRIPTION
Scrolling the PDF would cause onSingleTap to get called.

This PR does not consider a gesture a tap if the user's finger has moved too far. I chose 10 arbitrarily, it seemed to feel pretty natural when testing. This allows a user to scroll the PDF document without triggering the onSingleTap event handler.