### PR TITLE
Add React dependency to podspec

### DIFF
--- a/react-native-pdf.podspec
+++ b/react-native-pdf.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
   s.source        = { :git => 'https://github.com/wonday/react-native-pdf.git' }
   s.platform      = :ios, '8.0'
   s.source_files  = "ios/**/*.{h,m}"
+  s.dependency 'React'
 end


### PR DESCRIPTION
Add React dependency to podspec to support CocoaPods 1.5.0

CocoaPods 1.5.0 does no longer add all header search paths for each xcconfig generated and instead, it only adds the header search paths for the dependencies of the pod as stated in http://blog.cocoapods.org/CocoaPods-1.5.0/

As a result, implicit dependencies are no longer working.