### PR TITLE
fixed condition on cache expiration

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ export default class Pdf extends Component {
             RNFetchBlob.fs
                 .stat(cacheFile)
                 .then(stats => {
-                    if (!!!source.expiration || (source.expiration * 1000 + stats.lastModified) < (new Date().getTime())) {
+                    if (Boolean(source.expiration) || (source.expiration * 1000 + stats.lastModified) < (new Date().getTime())) {
                         // cache expirated then reload it
                         this._prepareFile(source);
                     } else {


### PR DESCRIPTION
The condition on the expiration is wrong, it doesn't work as described in the documentation.
given a source.expiration = undefined

!!!source.expiration -> true
Boolean(source.expiration) -> false