### PR TITLE
Add document page dimensions to the onLoadComplete callback

### DIFF
--- a/PdfView.js
+++ b/PdfView.js
@@ -86,15 +86,23 @@ export default class PdfView extends Component {
         PdfManager.loadFile(this.props.path, this.props.password)
             .then((pdfInfo) => {
                 if (this._mounted) {
+                    const fileNo = pdfInfo[0];
+                    const numberOfPages = pdfInfo[1];
+                    const width = pdfInfo[2];
+                    const height = pdfInfo[3];
+                    const pageAspectRatio = height === 0 ? 1 : width / height;
+
                     this.setState({
                         pdfLoaded: true,
-                        fileNo: pdfInfo[0],
-                        numberOfPages: pdfInfo[1],
-                        pageAspectRate: pdfInfo[3] === 0 ? 1 : pdfInfo[2] / pdfInfo[3],
-                        pdfPageSize: {width: pdfInfo[2], height: pdfInfo[3]},
-                        centerContent: pdfInfo[1]>1?false:true
+                        fileNo,
+                        numberOfPages,
+                        pageAspectRate: pageAspectRatio,
+                        pdfPageSize: {width, height},
+                        centerContent: numberOfPages > 1 ? false : true
                     });
-                    if (this.props.onLoadComplete) this.props.onLoadComplete(pdfInfo[1], this.props.path);
+                    if (this.props.onLoadComplete) {
+                        this.props.onLoadComplete(numberOfPages, this.props.path, {width, height});
+                    }
                 }
 
             })

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ const styles = StyleSheet.create({
 | activityIndicatorProps  | object      | {color:'#009900',progressTintColor:'#009900'} | activityIndicator props | ✔ | ✔ | 3.1 |
 | enableAntialiasing  | bool            | true        | improve rendering a little bit on low-res screens, but maybe course some problem on Android 4.4, so add a switch  | ✖   | ✔ | <3.0 |
 | onLoadProgress      | function(percent) | null        | callback when loading, return loading progress (0-1) | ✔   | ✔ | <3.0 |
-| onLoadComplete      | function(numberOfPages, path) | null        | callback when pdf load completed, return total page count and pdf local/cache path | ✔   | ✔ | <3.0 |
+| onLoadComplete      | function(numberOfPages, path, {width, height}) | null        | callback when pdf load completed, return total page count and pdf local/cache path | ✔   | ✔ | <3.0 |
 | onPageChanged       | function(page,numberOfPages)  | null        | callback when page changed ,return current page and total page count | ✔   | ✔ | <3.0 |
 | onError       | function(error) | null        | callback when error happened | ✔   | ✔ | <3.0 |
 | onPageSingleTap   | function(page)  | null        | callback when page was single tapped | ✔ | ✔ | 3.0 |


### PR DESCRIPTION
Include the document dimensions as a new third parameter to the `onLoadComplete` callback.

This information can be used by a parent component to resize itself to ensure that a complete page is shown when the document size could vary.