### PR TITLE
Add support for accessibility

### DIFF
--- a/PdfView.js
+++ b/PdfView.js
@@ -270,6 +270,7 @@ export default class PdfView extends Component {
                            }}
             >
                 <PdfPageView
+                    accessible={true}
                     key={item.id}
                     fileNo={this.state.fileNo}
                     page={item.key + 1}


### PR DESCRIPTION
In order for VoiceOver users to be able to scroll through the PDF pages, the `PdfPageView` must have an `accessible={true}` tag.