### PR TITLE
Style Prop Type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ import * as React from 'react';
 import * as ReactNative from 'react-native';
 
 interface Props {
-    style?: ReactNative.ViewStyle,
+    style?: ReactNative.StyleProp<ReactNative.ViewStyle>,
     source: object,
     page?: number,
     scale?: number,


### PR DESCRIPTION
## Summary
* Updated pdf component style prop type, previous type (```ViewStyle```) does not accept array of styles

## Demos

#### Current implementation ts compiler error ```style?: ReactNative.ViewStyle```
<img width="524" alt="screen shot 2019-01-09 at 3 51 55 pm" src="https://user-images.githubusercontent.com/40497468/50930827-9c978800-1426-11e9-92fe-3e2235e31c9b.png">


#### Proposed Change ```style?: ReactNative.StyleProp<ReactNative.ViewStyle>```
<img width="465" alt="screen shot 2019-01-09 at 3 51 08 pm" src="https://user-images.githubusercontent.com/40497468/50930838-a4572c80-1426-11e9-8bb4-e02c85e6553f.png">
