### PR TITLE
fix android build issues with react-native-pdf and react-native 59.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,15 @@ android {
     compileSdkVersion _compileSdkVersion
     buildToolsVersion _buildToolsVersion
 
+    packagingOptions {
+       pickFirst 'lib/x86/libc++_shared.so'
+       pickFirst 'lib/x86_64/libjsc.so'
+       pickFirst 'lib/arm64-v8a/libjsc.so'
+       pickFirst 'lib/arm64-v8a/libc++_shared.so'
+       pickFirst 'lib/x86_64/libc++_shared.so'
+       pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+     }
+
     defaultConfig {
         minSdkVersion _minSdkVersion
         targetSdkVersion _targetSdkVersion


### PR DESCRIPTION
Hi,
I managed to fix the issue (that was already opened previously: react-native-pdf:transformNativeLibsWithMergeJniLibsForDebugAndroidTest) 
by adding those lines to the build.gradle file.

after the change build ends successfully.
