### PR TITLE
Add activityIndicatorProps to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ interface Props {
     spacing?: number,
     password?: string,
     activityIndicator?: any,
+    activityIndicatorProps?: object,
     enableAntialiasing?: boolean,
     enablePaging?: boolean,
     enableRTL?: boolean,


### PR DESCRIPTION
The optional `activityIndicatorProps` prop is currently missing from the TypeScript definition.