### PR TITLE
Added packagingOptions to android build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,15 @@ android {
     lintOptions {
         abortOnError true
     }
+
+    packagingOptions {
+       pickFirst 'lib/x86/libc++_shared.so'
+       pickFirst 'lib/x86_64/libjsc.so'
+       pickFirst 'lib/arm64-v8a/libjsc.so'
+       pickFirst 'lib/arm64-v8a/libc++_shared.so'
+       pickFirst 'lib/x86_64/libc++_shared.so'
+       pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
While the work around of adding packagingOptions to the project using react-native-pdf works for the standard debug and release targets, Detox e2e tests build and androidTest target that the work around does not work for, however this change does fix this issue for the Detox build.