### PR TITLE
Fix blank view after native module got recycled

### DIFF
--- a/android/src/main/java/org/wonday/pdf/PdfView.java
+++ b/android/src/main/java/org/wonday/pdf/PdfView.java
@@ -198,6 +198,12 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
 
     }
 
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        if (this.isRecycled())
+            this.drawPdf();
+    }
 
     public void drawPdf() {
         showLog(format("drawPdf path:%s %s", this.path, this.page));


### PR DESCRIPTION
The native dependency [AndroidPdfViewer](https://github.com/barteksc/AndroidPdfViewer/blob/690e2cf3cfa65506cd8a6d176f7c0c0e2beebb8e/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java#L464) is recycling the view in onDetachedFromWindow event. Components like a tabview or the [react-native-viewpager](https://github.com/react-native-community/react-native-viewpager) are not unmounting the component when the native module is detached. We won't have a mount or render callback after returning to the previously loaded pdf page even if the pdf file was unloaded which leads to a blank page.

Steps to reproduce are described in the [example project's](https://github.com/MichaelHettmer/react-native-pdf-fixNativeDetach-example) README.md.

This pull request fixes the described issue by simply calling drawPdf() again in onAttachedToWindow().

Potential fix for #313 and #329.