### PR TITLE
Explicitly set the height on pdf style on example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ const styles = StyleSheet.create({
     pdf: {
         flex:1,
         width:Dimensions.get('window').width,
+        height:Dimensions.get('window').height,
     }
 });
 


### PR DESCRIPTION
I was stumbled into why I can't see my PDF file, it's all loaded and no errors. And it's actually because I haven't explicitly set the height, probably other people would stumble upon this so it would be better to add this into the example.