### PR TITLE
Feature/link press callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,18 +51,18 @@ android {
 
 ### FAQ
 
-Q1. After installation and running, I can not see the pdf file.  
+Q1. After installation and running, I can not see the pdf file.
 A1: maybe you forgot to excute ```react-native link``` or it does not run correctly.
 You can add it manually. For detail you can see the issue [`#24`](https://github.com/wonday/react-native-pdf/issues/24) and [`#2`](https://github.com/wonday/react-native-pdf/issues/2)
 
-Q2. When running, it shows ```'Pdf' has no propType for native prop RCTPdf.acessibilityLabel of native type 'String'```  
+Q2. When running, it shows ```'Pdf' has no propType for native prop RCTPdf.acessibilityLabel of native type 'String'```
 A2. Your react-native version is too old, please upgrade it to 0.47.0+ see also [`#39`](https://github.com/wonday/react-native-pdf/issues/39)
 
-Q3. When I run the example app I get a white/gray screen / the loading bar isn't progressing .  
+Q3. When I run the example app I get a white/gray screen / the loading bar isn't progressing .
 A3. Check your uri, if you hit a pdf that is hosted on a `http` you will need to do the following:
 
 **iOS:**
-add an exception for the server hosting the pdf in the ios `info.plist`. Here is an example :  
+add an exception for the server hosting the pdf in the ios `info.plist`. Here is an example :
 
 ```
 <key>NSAppTransportSecurity</key>
@@ -88,7 +88,7 @@ add an exception for the server hosting the pdf in the ios `info.plist`. Here is
 **Android:**
 [`see here`](https://stackoverflow.com/questions/54818098/cleartext-http-traffic-not-permitted)
 
-Q4. why doesn't it work with react native expo?.  
+Q4. why doesn't it work with react native expo?.
 A4. Expo does not support native module. you can read more expo caveats [`here`](https://facebook.github.io/react-native/docs/getting-started.html#caveats)
 
 Q5. Why can't I run the iOS example? `'Failed to build iOS project. We ran "xcodebuild" command but it exited with error code 65.'`
@@ -177,6 +177,9 @@ export default class PDFExample extends React.Component {
                     onError={(error)=>{
                         console.log(error);
                     }}
+                    onPressLink={(uri)=>{
+                        console.log(`Link presse: ${uri}`)
+                    }}
                     style={styles.pdf}/>
             </View>
         )
@@ -227,6 +230,7 @@ const styles = StyleSheet.create({
 | onError       | function(error) | null        | callback when error happened | ✔   | ✔ | <3.0 |
 | onPageSingleTap   | function(page)  | null        | callback when page was single tapped | ✔ | ✔ | 3.0 |
 | onScaleChanged    | function(scale) | null        | callback when scale page | ✔ | ✔ | 3.0 |
+| onPressLink       | function(uri)   | null        | callback when link tapped | ✔ | ✔ | 5.1.? |
 
 #### parameters of source
 

--- a/android/src/main/java/org/wonday/pdf/PdfView.java
+++ b/android/src/main/java/org/wonday/pdf/PdfView.java
@@ -32,6 +32,8 @@ import com.github.barteksc.pdfviewer.listener.OnDrawListener;
 import com.github.barteksc.pdfviewer.listener.OnPageScrollListener;
 import com.github.barteksc.pdfviewer.util.FitPolicy;
 import com.github.barteksc.pdfviewer.util.Constants;
+import com.github.barteksc.pdfviewer.link.LinkHandler;
+import com.github.barteksc.pdfviewer.model.LinkTapEvent;
 
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactContext;
@@ -53,7 +55,7 @@ import com.shockwave.pdfium.PdfDocument;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompleteListener,OnErrorListener,OnTapListener,OnDrawListener,OnPageScrollListener {
+public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompleteListener,OnErrorListener,OnTapListener,OnDrawListener,OnPageScrollListener, LinkHandler {
     private ThemedReactContext context;
     private int page = 1;               // start from 1
     private boolean horizontal = false;
@@ -107,10 +109,10 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
 
         float width = this.getWidth();
         float height = this.getHeight();
-        
+
         this.zoomTo(this.scale);
         WritableMap event = Arguments.createMap();
-        
+
         //create a new jason Object for the TableofContents
         Gson gson = new Gson();
         event.putString("message", "loadComplete|"+numberOfPages+"|"+width+"|"+height+"|"+gson.toJson(this.getTableOfContents()));
@@ -120,7 +122,7 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
             "topChange",
             event
          );
-        
+
         //Log.e("ReactNative", gson.toJson(this.getTableOfContents()));
 
     }
@@ -234,6 +236,7 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
                 .autoSpacing(this.autoSpacing)
                 .pageFling(this.pageFling)
                 .enableAnnotationRendering(this.enableAnnotationRendering)
+                .linkHandler(this)
                 .load();
 
         }
@@ -309,6 +312,41 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
             }
         }
 
+    }
+
+    /**
+     * @see https://github.com/barteksc/AndroidPdfViewer/blob/master/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/link/DefaultLinkHandler.java
+     */
+    public void handleLinkEvent(LinkTapEvent event) {
+        String uri = event.getLink().getUri();
+        Integer page = event.getLink().getDestPageIdx();
+        if (uri != null && !uri.isEmpty()) {
+            handleUri(uri);
+        } else if (page != null) {
+            handlePage(page);
+        }
+    }
+
+    /**
+     * @see https://github.com/barteksc/AndroidPdfViewer/blob/master/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/link/DefaultLinkHandler.java
+     */
+    private void handleUri(String uri) {
+        WritableMap event = Arguments.createMap();
+        event.putString("message", "linkPressed|"+uri);
+
+        ReactContext reactContext = (ReactContext)this.getContext();
+        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
+            this.getId(),
+            "topChange",
+            event
+        );
+    }
+
+    /**
+     * @see https://github.com/barteksc/AndroidPdfViewer/blob/master/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/link/DefaultLinkHandler.java
+     */
+    private void handlePage(int page) {
+        this.jumpTo(page);
     }
 
     private void showLog(final String str) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,7 @@ interface Props {
     onError?: (error: object) => void,
     onPageSingleTap?: (page: number) => void,
     onScaleChanged?: (scale: number) => void,
+    onPressLink?: (url: string) => void,
 }
 
 declare class Pdf extends React.Component<Props, any> {

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ export default class Pdf extends Component {
         onError: PropTypes.func,
         onPageSingleTap: PropTypes.func,
         onScaleChanged: PropTypes.func,
+        onPressLink: PropTypes.func,
 
         // Props that are not available in the earlier react native version, added to prevent crashed on android
         accessibilityLabel: PropTypes.string,
@@ -94,6 +95,8 @@ export default class Pdf extends Component {
         onPageSingleTap: (page) => {
         },
         onScaleChanged: (scale) => {
+        },
+        onPressLink: (url) => {
         },
     };
 
@@ -352,6 +355,8 @@ export default class Pdf extends Component {
                 this.props.onPageSingleTap && this.props.onPageSingleTap(message[1]);
             } else if (message[0] === 'scaleChanged') {
                 this.props.onScaleChanged && this.props.onScaleChanged(message[1]);
+            } else if (message[0] === 'linkPressed') {
+                this.props.onPressLink && this.props.onPressLink(message[1]);
             }
         }
 
@@ -414,6 +419,7 @@ export default class Pdf extends Component {
                                                 onError={this._onError}
                                                 onPageSingleTap={this.props.onPageSingleTap}
                                                 onScaleChanged={this.props.onScaleChanged}
+                                                onPressLink={this.props.onPressLink}
                                             />)
                                     )
                                 )}

--- a/index.js.flow
+++ b/index.js.flow
@@ -47,6 +47,7 @@ export type Props = {
   onPageChanged?: (page: number, numberOfPages: number) => void,
   onPageSingleTap?: (page: number) => void,
   onScaleChanged?: (scale: number) => void,
+  onPressLink?: (url: string) => void,
   page?: number,
   password?: string,
   scale?: number,

--- a/ios/RCTPdf/RCTPdfView.m
+++ b/ios/RCTPdf/RCTPdfView.m
@@ -45,7 +45,6 @@ const float MIN_SCALE = 1.0f;
     float _fixScaleFactor;
     bool _initialed;
     NSArray<NSString *> *_changedProps;
-    
 }
 
 - (instancetype)init
@@ -85,12 +84,22 @@ const float MIN_SCALE = 1.0f;
         [center addObserver:self selector:@selector(onScaleChanged:) name:PDFViewScaleChangedNotification object:_pdfView];
         
         [[_pdfView document] setDelegate: self];
+        [_pdfView setDelegate: self];
         
         
         [self bindTap];
     }
     
     return self;
+}
+
+- (void)PDFViewWillClickOnLink:(PDFView *)sender withURL:(NSURL *)url
+{
+    NSString *_url = url.absoluteString;
+    _onChange(@{ @"message":
+                     [[NSString alloc] initWithString:
+                      [NSString stringWithFormat:
+                       @"linkPressed|%s", _url.UTF8String]] });
 }
 
 - (void)didSetProps:(NSArray<NSString *> *)changedProps


### PR DESCRIPTION
As explained in #384 it's not possible to listen to link presses inside of pdf documents.

Behavior on Android: com.github.barteksc.pdfviewer.link.DefaultLinkHandler will open the Android default intent.
Behavior on iOS: Nothing will happen

**Solution:**

This PR implements a common event `onPressLink` callback for the pdf view. Any behavior after the link press needs to be implemented in react-native now (no matter if it's Android or iOS).

---

**Android implementation:**

Using the `linkHandler` configuration ([explained here](https://github.com/barteksc/AndroidPdfViewer#links)) by implementing `LinkHandler` directly inside `PdfView` and dispatching the new `linkPressed` event.

**iOS implementation:**

The PDFView on iOS will call `PDFViewWillClickOnLink` on it's delegate ([documented here](https://developer.apple.com/documentation/pdfkit/pdfviewdelegate/1690923-pdfviewwillclickonlink?language=objc)). To get the event, the `RCTPdfView` is set as delegate for the `PDFView`. Again, the new `linkPressed` event is dispatched.