### PR TITLE
Expose option "trustAllCerts" to to allow/deny self-signed certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ const styles = StyleSheet.create({
 | enablePaging  | bool            | false        | only show one page in screen   | ✔ | ✔ | 5.0.1 |
 | enableRTL  | bool            | false        | scroll page as "page3, page2, page1"  | ✔   | ✖ | 5.0.1 |
 | enableAnnotationRendering  | bool            | true        | enable rendering annotation, notice:iOS only support initial setting,not support realtime changing  | ✔ | ✔ | 5.0.3 |
+| trustAllCerts  | bool            | true        | Allow connections to servers with self-signed certification  | ✔ | ✔ | 6.0.? |
 | onLoadProgress      | function(percent) | null        | callback when loading, return loading progress (0-1) | ✔   | ✔ | <3.0 |
 | onLoadComplete      | function(numberOfPages, path, {width, height}, tableContents) | null        | callback when pdf load completed, return total page count, pdf local/cache path, {width,height} and table of contents | ✔   | ✔ | <3.0 |
 | onPageChanged       | function(page,numberOfPages)  | null        | callback when page changed ,return current page and total page count | ✔   | ✔ | <3.0 |

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ interface Props {
     enableRTL?: boolean,
     enableAnnotationRendering?: boolean,
     fitPolicy?: number,
+    trustAllCerts?: boolean,
     onLoadProgress?: (percent: number,) => void,
     onLoadComplete?: (numberOfPages: number, path: string) => void,
     onPageChanged?: (page: number, numberOfPages: number) => void,

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ export default class Pdf extends Component {
         enablePaging: PropTypes.bool,
         enableRTL: PropTypes.bool,
         fitPolicy: PropTypes.number,
+        trustAllCerts: PropTypes.bool,
         onLoadComplete: PropTypes.func,
         onPageChanged: PropTypes.func,
         onError: PropTypes.func,
@@ -84,6 +85,7 @@ export default class Pdf extends Component {
         enablePaging: false,
         enableRTL: false,
         activityIndicatorProps: {color: '#009900', progressTintColor: '#009900'},
+        trustAllCerts: true,
         onLoadProgress: (percent) => {
         },
         onLoadComplete: (numberOfPages, path) => {
@@ -264,7 +266,7 @@ export default class Pdf extends Component {
         this.lastRNBFTask = RNFetchBlob.config({
             // response data will be saved to this path if it has access right.
             path: tempCacheFile,
-            trusty: true,
+            trusty: this.props.trustAllCerts,
         })
             .fetch(
                 source.method ? source.method : 'GET',


### PR DESCRIPTION
Currently, rn-fetch-blob is used to fetch a PDF with config option `trusty = true` ([link](https://github.com/joltup/rn-fetch-blob#self-signed-ssl-server)). I have added a prop called "trustAllCerts" to allow the user to set the trusty option.

**Note:** I have set the default value of trustAllCerts as `true` to keep the old behavior. However, it might be better to set the default value as `false` for security reasons.