### PR TITLE
Set the PDF View background color to be transparent so we see the style prop color

### DIFF
--- a/ios/RCTPdf/RCTPdfView.m
+++ b/ios/RCTPdf/RCTPdfView.m
@@ -69,7 +69,8 @@ const float MIN_SCALE = 1.0f;
         _pdfView.autoScales = YES;
         _pdfView.displaysPageBreaks = YES;
         _pdfView.displayBox = kPDFDisplayBoxCropBox;
-        
+        _pdfView.backgroundColor = [UIColor clearColor];
+
         _fixScaleFactor = -1.0f;
         _initialed = NO;
         _changedProps = NULL;


### PR DESCRIPTION
Currently on iOS, setting the background color via the style props doesn't work because the native PDF view is rendereing it's own grey BG color. Setting it to be transparent allows the color from the react style prop to show through.

I will be using this in a production app, and it will have a couple of different background colors in different places, but Please let me know if this would somehow cause issues!

Thanks!