### PR TITLE
Bump dependency to support React-Native >= 0.62

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "crypto-js": "^3.2.0",
         "prop-types": "^15.7.2",
-        "@react-native-community/progress-bar-android": "^1.0.2",
-        "@react-native-community/progress-view": "^1.0.2"
+        "@react-native-community/progress-bar-android": "^1.0.3",
+        "@react-native-community/progress-view": "^1.0.3"
     }
 }


### PR DESCRIPTION
Version 1.0.3 of _react-native-community/progress-bar-android_ & _react-native-community/progress-view_ is required to be able to run on React-Native >= 0.62