### PR TITLE
update android-pdf-viewer dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,6 +52,6 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:${_reactNativeVersion}"
-    implementation 'com.github.barteksc:android-pdf-viewer:3.1.0-beta.1'
+    implementation 'com.github.barteksc:android-pdf-viewer:3.+'
     implementation 'com.google.code.gson:gson:2.8.5'
 }


### PR DESCRIPTION
android-pdf-viewer dependency was on an unstable beta version
this updates to the next stable version.

issue link: https://github.com/wonday/react-native-pdf/issues/291