### PR TITLE
Switching the AndroidPdfViewer dependency from to another repo.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,13 @@ buildscript {
 
 repositories {
     jcenter()
+    maven {
+        url 'https://jitpack.io'
+        content {
+            // Use Jitpack only for AndroidPdfViewer; the rest is hosted at jcenter.
+            includeGroup "com.github.TalbotGooday"
+        }
+    }
 }
 
 apply plugin: 'com.android.library'
@@ -52,6 +59,8 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:${_reactNativeVersion}"
-    implementation 'com.github.barteksc:android-pdf-viewer:3.1.0-beta.1'
+    // NOTE: The original repo at com.github.barteksc is abandoned by the maintainer; there will be no more updates coming from that repo.
+    //       It was taken over by com.github.TalbotGooday; from now on please use this repo until (if ever) the Barteksc repo is resumed.
+    implementation 'com.github.TalbotGooday:AndroidPdfViewer:3.1.0-beta.3'
     implementation 'com.google.code.gson:gson:2.8.5'
 }


### PR DESCRIPTION
**The original repo at `com.github.barteksc` is abandoned by the maintainer.** The last release was made in September 2019 and there seem to be no more updates ever coming from that repo. The work was taken over by `com.github.TalbotGooday`.

TalbotGooday released a minor update which supports AndroidX. It is important to switch to TalbotGooday if we want to have AndroidX support in our library.

Version numbering is not consistent between the two repos so don't get confused:

Old repo (Barteksc) | New repo (TalbotGooday)
------------------- | --------------------------
3.0.0-beta.4   (Dec, 2017) | -
3.2.0-beta.1   (Sep, 2019) | -
 =                                         | 3.1.0-beta.2   (May, 2020)
 =                                         | 3.1.0-beta.3   (Aug, 2020)

From now on please use this repo until (if ever) the Barteksc repo is resumed.

TalbotGooday's artefact is hosted at Jitpack (at the moment of writing).