### PR TITLE
fix: conditional require of rn-fetch-blob

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ let RNFetchBlob = {
     }
 };
 if (Platform.OS !== 'windows') {
-    RNFetchBlob = require('rn-fetch-blob');
+    RNFetchBlob = require('rn-fetch-blob').default;
 }
 
 const SHA1 = require('crypto-js/sha1');


### PR DESCRIPTION
Fixes conditional require of `rn-fetch-blob` on Android and iOS.

Currently, running the sample code fails with the runtime error `undefined is not an object (evaluating 'RNFetchBlob.fs.dirs')`.
This PR fixes this runtime error.