### PR TITLE
Update `progress-bar-anrdoid`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "crypto-js": "^3.2.0",
         "prop-types": "^15.7.2",
-        "@react-native-community/progress-bar-android": "^1.0.3",
+        "@react-native-community/progress-bar-android": "^1.0.4",
         "@react-native-community/progress-view": "^1.0.3"
     }
 }


### PR DESCRIPTION
progress-bar-anrdoid 1.0.3 does not work on RN 0.60 - see https://github.com/react-native-progress-view/progress-bar-android/issues/51