### PR TITLE
fix [iOS]: Setting _pdfView.backgroundColor after calling pdfView.document

### DIFF
--- a/ios/RCTPdf/RCTPdfView.m
+++ b/ios/RCTPdf/RCTPdfView.m
@@ -275,7 +275,7 @@ const float MIN_SCALE = 1.0f;
             }
         }
 
-
+        _pdfView.backgroundColor = [UIColor clearColor];
         [_pdfView layoutDocumentView];
         [self setNeedsDisplay];
     }


### PR DESCRIPTION
This is fixing an issue on iOS versions below 13 where the native PDF View is rendering it's own gray background. It's actually building on this identical issue #233  and this pull request #443 .

However according to [this article](https://medium.com/better-programming/ios-pdfkit-ink-annotations-tutorial-4ba19b474dce) "Calling `pdfView.document = ...` resets PDFView’s background color to default. So, call `pdfView.backgroundColor = ...` after `pdfView.document = ...`."