### PR TITLE
Add support for setting a filename to the cached pdf file

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ const styles = StyleSheet.create({
 | ------------ | ----------- | ------- | --- | ------- | ------- |
 | uri          | pdf source, see the forllowing for detail.| required | ✔   | ✔ | ✔ |
 | cache        | use cache or not | false | ✔ | ✔ | ✖ |
+| cacheFileName | specific file name for cached pdf file | SHA1(uri) result | ✔ | ✔ | ✖ |
 | expiration   | cache file expired seconds (0 is not expired) | 0 | ✔ | ✔ | ✖ |
 | method       | request method when uri is a url | "GET" | ✔ | ✔ | ✖ |
 | headers      | request headers when uri is a url | {} | ✔ | ✔ | ✖ |

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ export default class Pdf extends Component {
             PropTypes.shape({
                 uri: PropTypes.string,
                 cache: PropTypes.bool,
+                cacheFileName: PropTypes.string,
                 expiration: PropTypes.number,
             }),
             // Opaque type returned by require('./test.pdf')
@@ -182,7 +183,8 @@ export default class Pdf extends Component {
         if (this._mounted) {
             this.setState({isDownloaded: false, path: '', progress: 0});
         }
-        const cacheFile = RNFetchBlob.fs.dirs.CacheDir + '/' + SHA1(uri) + '.pdf';
+        const filename = source.cacheFileName || SHA1(uri) + '.pdf';
+        const cacheFile = RNFetchBlob.fs.dirs.CacheDir + '/' + filename;
 
         if (source.cache) {
             RNFetchBlob.fs
@@ -216,7 +218,8 @@ export default class Pdf extends Component {
                 const isAsset = !!(uri && uri.match(/^bundle-assets:\/\//));
                 const isBase64 = !!(uri && uri.match(/^data:application\/pdf;base64/));
 
-                const cacheFile = RNFetchBlob.fs.dirs.CacheDir + '/' + SHA1(uri) + '.pdf';
+                const filename = source.cacheFileName || SHA1(uri) + '.pdf';
+                const cacheFile = RNFetchBlob.fs.dirs.CacheDir + '/' + filename;
 
                 // delete old cache file
                 this._unlinkFile(cacheFile);

--- a/index.js.flow
+++ b/index.js.flow
@@ -17,6 +17,7 @@ export type FitBoth = 2;
 export type Source = {
   body?: string | FormField[],
   cache?: boolean,
+  cacheFileName?: string,
   expiration?: number,
   headers?: { [key: string]: string },
   method?: Methods,


### PR DESCRIPTION
Gives the ability to add a specific filename when caching the downloaded pdf instead of using `SHA1(uri).pdf`. This way, when trying to share it, the file can have a human-friendly filename.