### PR TITLE
Remove rn fetch blob

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -27,7 +27,7 @@
     "react-native-orientation-locker": "^1.1.6",
     "react-native-pdf": "file:../",
     "react-native-windows": "^0.63.11",
-    "rn-fetch-blob": "^0.10.16"
+    "react-native-blob-util": "^0.13.7",
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/index.js
+++ b/index.js
@@ -20,20 +20,7 @@ import {
 
 import { ProgressBar } from '@react-native-community/progress-bar-android'
 import { ProgressView } from '@react-native-community/progress-view'
-
-let RNFetchBlob;
-try {
-    RNFetchBlob = require('rn-fetch-blob').default;
-} catch(e) {
-    // For Windows, when not using rn-fetch-blob with Windows support.
-    RNFetchBlob = {
-        fs : {
-            dirs: {
-                CacheDir: ''
-            }
-        }
-    };
-}
+import ReactNativeBlobUtil from 'react-native-blob-util'
 
 const SHA1 = require('crypto-js/sha1');
 import PdfView from './PdfView';
@@ -184,10 +171,10 @@ export default class Pdf extends Component {
             this.setState({isDownloaded: false, path: '', progress: 0});
         }
         const filename = source.cacheFileName || SHA1(uri) + '.pdf';
-        const cacheFile = RNFetchBlob.fs.dirs.CacheDir + '/' + filename;
+        const cacheFile = ReactNativeBlobUtil.fs.dirs.CacheDir + '/' + filename;
 
         if (source.cache) {
-            RNFetchBlob.fs
+            ReactNativeBlobUtil.fs
                 .stat(cacheFile)
                 .then(stats => {
                     if (!Boolean(source.expiration) || (source.expiration * 1000 + stats.lastModified) > (new Date().getTime())) {
@@ -219,7 +206,7 @@ export default class Pdf extends Component {
                 const isBase64 = !!(uri && uri.match(/^data:application\/pdf;base64/));
 
                 const filename = source.cacheFileName || SHA1(uri) + '.pdf';
-                const cacheFile = RNFetchBlob.fs.dirs.CacheDir + '/' + filename;
+                const cacheFile = ReactNativeBlobUtil.fs.dirs.CacheDir + '/' + filename;
 
                 // delete old cache file
                 this._unlinkFile(cacheFile);
@@ -227,7 +214,7 @@ export default class Pdf extends Component {
                 if (isNetwork) {
                     this._downloadFile(source, cacheFile);
                 } else if (isAsset) {
-                    RNFetchBlob.fs
+                    ReactNativeBlobUtil.fs
                         .cp(uri, cacheFile)
                         .then(() => {
                             if (this._mounted) {
@@ -240,7 +227,7 @@ export default class Pdf extends Component {
                         })
                 } else if (isBase64) {
                     let data = uri.replace(/data:application\/pdf;base64,/i, '');
-                    RNFetchBlob.fs
+                    ReactNativeBlobUtil.fs
                         .writeFile(cacheFile, data, 'base64')
                         .then(() => {
                             if (this._mounted) {
@@ -280,7 +267,7 @@ export default class Pdf extends Component {
         const tempCacheFile = cacheFile + '.tmp';
         this._unlinkFile(tempCacheFile);
 
-        this.lastRNBFTask = RNFetchBlob.config({
+        this.lastRNBFTask = ReactNativeBlobUtil.config({
             // response data will be saved to this path if it has access right.
             path: tempCacheFile,
             trusty: this.props.trustAllCerts,
@@ -309,7 +296,7 @@ export default class Pdf extends Component {
                     let actualContentLength;
 
                     try {
-                        const fileStats = await RNFetchBlob.fs.stat(res.path());
+                        const fileStats = await ReactNativeBlobUtil.fs.stat(res.path());
 
                         if (!fileStats || !fileStats.size) {
                             throw new Error("FileNotFound:" + source.uri);
@@ -326,7 +313,7 @@ export default class Pdf extends Component {
                 }
 
                 this._unlinkFile(cacheFile);
-                RNFetchBlob.fs
+                ReactNativeBlobUtil.fs
                     .cp(tempCacheFile, cacheFile)
                     .then(() => {
                         if (this._mounted) {
@@ -348,7 +335,7 @@ export default class Pdf extends Component {
 
     _unlinkFile = async (file) => {
         try {
-            await RNFetchBlob.fs.unlink(file);
+            await ReactNativeBlobUtil.fs.unlink(file);
         } catch (e) {
 
         }


### PR DESCRIPTION
As @imranMnts said on #575, rn-fetch-blob is unmaintained since september 2020 joltup/rn-fetch-blob#666 so I'm making this PR to change that library and use [react-native-blob-util](https://github.com/RonRadtke/react-native-blob-util) as @imranMnts suggested.

react-native-blob-util supports windows, so I think the try/catch on [index.js:25](https://github.com/wonday/react-native-pdf/blob/master/index.js#L25) is not needed anymore, and the library can be imported normally.