### PR TITLE
replace deprecated jcenter()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ description = 'react-native-pdf'
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 
@@ -12,11 +12,11 @@ buildscript {
 }
 
 repositories {
-    jcenter()
-    maven {
+    mavenCentral()
+    mavenCentral {
         url 'https://jitpack.io'
         content {
-            // Use Jitpack only for AndroidPdfViewer; the rest is hosted at jcenter.
+            // Use Jitpack only for AndroidPdfViewer; the rest is hosted at mavenCentral.
             includeGroup "com.github.TalbotGooday"
         }
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 repositories {
     mavenCentral()
-    mavenCentral {
+    maven {
         url 'https://jitpack.io'
         content {
             // Use Jitpack only for AndroidPdfViewer; the rest is hosted at mavenCentral.

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.4.1")
@@ -33,6 +33,6 @@ allprojects {
         }
 
         google()
-        jcenter()
+        mavenCentral()
     }
 }


### PR DESCRIPTION
`jcenter()` deprecated, so it should be replaced by `mavenCentral()`
https://blog.gradle.org/jcenter-shutdown