### PR TITLE
Don't floor progress value when setting progress state

### DIFF
--- a/index.js
+++ b/index.js
@@ -278,7 +278,7 @@ export default class Pdf extends Component {
             .progress((received, total) => {
                 this.props.onLoadProgress && this.props.onLoadProgress(received / total);
                 if (this._mounted) {
-                    this.setState({progress: Math.floor(received / total)});
+                    this.setState({progress: received / total});
                 }
             });
 


### PR DESCRIPTION
The download progress is a percentage—a value between 0 and 1. Flooring it will cause it to always be set to 0. Any formatting this value should be the responsibility of the progress rendering function.

This fixes issue #603.