### PR TITLE
Fix formatting of default progress text to use two fixed decimal places

### DIFF
--- a/index.js
+++ b/index.js
@@ -397,7 +397,7 @@ export default class Pdf extends Component {
                             >
                                 {this.props.renderActivityIndicator
                                     ? this.props.renderActivityIndicator(this.state.progress)
-                                    : <Text>{`${(Math.round(this.state.progress*10000)/100).toFixed(0)}%`}</Text>}
+                                    : <Text>{`${(this.state.progress * 100).toFixed(2)}%`}</Text>}
                             </View>):(
                                 Platform.OS === "android" || Platform.OS === "windows"?(
                                         <PdfCustom


### PR DESCRIPTION
The previous version was rounding to two decimal then rounding to no decimals.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed#description