### PR TITLE
feat: get page coordinate instead of view coord

### DIFF
--- a/PdfView.js
+++ b/PdfView.js
@@ -57,7 +57,7 @@ export default class PdfView extends Component {
         currentPage: -1,
         enablePaging: false,
         singlePage: false,
-        onPageSingleTap: (page, x, y) => {
+        onPageSingleTap: (page, pageWidth, pageHeight, x, y) => {
         },
         onScaleChanged: (scale) => {
         },
@@ -222,7 +222,7 @@ export default class PdfView extends Component {
 
     _onItemSingleTap = (index, x, y) => {
 
-        this.props.onPageSingleTap(index + 1, x, y);
+        this.props.onPageSingleTap(index + 1, this._getPageWidth, this._getPageHeight, x, y);
 
     };
 

--- a/android/src/main/java/org/wonday/pdf/PdfView.java
+++ b/android/src/main/java/org/wonday/pdf/PdfView.java
@@ -166,8 +166,25 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
         //Constants.Pinch.MINIMUM_ZOOM = this.minScale;
         //Constants.Pinch.MAXIMUM_ZOOM = this.maxScale;
 
+        int totalWidth = (int) this.toCurrentScale((this.getPageCount() * ((this.getPageSize(page).getWidth() + this.getSpacingPx()))));
+        int currentPage = (int) ((this.getPageCount() * (Math.abs(this.getCurrentXOffset()) + e.getX())) / totalWidth);
+        SizeF pageSize = getPageSize(currentPage);
+        float pageWidth = this.toCurrentScale(pageSize.getWidth());
+        float pageHeight = this.toCurrentScale(pageSize.getHeight());
+
+        float x = ((((Math.abs(this.getCurrentXOffset()) + e.getX()) / pageWidth) - currentPage)
+                * pageWidth
+                - (this.toCurrentScale(this.getSpacingPx()) * currentPage));
+        float y = (Math.abs(this.getCurrentYOffset()) + e.getY());
+
         WritableMap event = Arguments.createMap();
-        event.putString("message", "pageSingleTap|"+page+"|"+e.getX()+"|"+e.getY());
+        event.putString("message",
+                "pageSingleTap"
+                +"|"+(currentPage + 1)
+                +"|"+pageWidth
+                +"|"+pageHeight
+                +"|"+x
+                +"|"+y);
 
         ReactContext reactContext = (ReactContext)this.getContext();
         reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ interface Props {
     onLoadComplete?: (numberOfPages: number, path: string, size: {height: number, width: number}, tableContents?: TableContent[]) => void,
     onPageChanged?: (page: number, numberOfPages: number) => void,
     onError?: (error: object) => void,
-    onPageSingleTap?: (page: number, x: number, y: number) => void,
+    onPageSingleTap?: (page: number, pageWidth: number, pageHeight: number, x: number, y: number) => void,
     onScaleChanged?: (scale: number) => void,
     onPressLink?: (url: string) => void,
 }

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ export default class Pdf extends Component {
         },
         onError: (error) => {
         },
-        onPageSingleTap: (page, x, y) => {
+        onPageSingleTap: (page, pageWidth, pageHeight, x, y) => {
         },
         onScaleChanged: (scale) => {
         },
@@ -357,10 +357,10 @@ export default class Pdf extends Component {
         let message = event.nativeEvent.message.split('|');
         //__DEV__ && console.log("onChange: " + message);
         if (message.length > 0) {
-            if (message.length > 5) {
-                message[4] = message.splice(4).join('|');
-            }
             if (message[0] === 'loadComplete') {
+                if (message.length > 5) {
+                    message[4] = message.splice(4).join('|');
+                }
                 this.props.onLoadComplete && this.props.onLoadComplete(Number(message[1]), this.state.path, {
                     width: Number(message[2]),
                     height: Number(message[3]),
@@ -371,7 +371,7 @@ export default class Pdf extends Component {
             } else if (message[0] === 'error') {
                 this._onError(new Error(message[1]));
             } else if (message[0] === 'pageSingleTap') {
-                this.props.onPageSingleTap && this.props.onPageSingleTap(Number(message[1]), Number(message[2]), Number(message[3]));
+                this.props.onPageSingleTap && this.props.onPageSingleTap(Number(message[1]), Number(message[2]), Number(message[3]), Number(message[4]), Number(message[5]));
             } else if (message[0] === 'scaleChanged') {
                 this.props.onScaleChanged && this.props.onScaleChanged(Number(message[1]));
             } else if (message[0] === 'linkPressed') {

--- a/ios/RCTPdf/RCTPdfView.m
+++ b/ios/RCTPdf/RCTPdfView.m
@@ -504,7 +504,9 @@ const float MIN_SCALE = 1.0f;
     PDFPage *pdfPage = [_pdfView pageForPoint:point nearest:NO];
     if (pdfPage) {
         unsigned long page = [_pdfDocument indexForPage:pdfPage];
-        _onChange(@{ @"message": [[NSString alloc] initWithString:[NSString stringWithFormat:@"pageSingleTap|%lu|%f|%f", page+1, point.x, point.y]]});
+        CGPoint locationOnPage = [_pdfView convertPoint:point toPage:pdfPage];
+        CGRect pageRect = [pdfPage boundsForBox:kPDFDisplayBoxCropBox];
+        _onChange(@{ @"message": [[NSString alloc] initWithString:[NSString stringWithFormat:@"pageSingleTap|%lu|%f|%f|%f|%f", page+1, pageRect.size.width, pageRect.size.height, locationOnPage.x, locationOnPage.y]]});
     }
 
     //[self setNeedsDisplay];


### PR DESCRIPTION
A simple code to retrieve clicked coordinates on a PDF page instead of coordinates on the full view.

The goal is to provide a valid code to perform this behavior.

Depending on what you want, you may need to adapt the code to have two methods: `onViewSingleTap` that returns the coordinates for the view and `onPageSingleTap` to get the coordinates for the clicked page. 