### PR TITLE
fixed error -" Migrate to ViewPropTypes exported from 'deprecated-rea…

### DIFF
--- a/DoubleTapView.js
+++ b/DoubleTapView.js
@@ -10,11 +10,10 @@
 import React, {Component} from 'react';
 import {
     View,
-    PanResponder,
-    ViewPropTypes,
+    PanResponder
 } from 'react-native';
 import PropTypes from 'prop-types';
-
+import {ViewPropTypes} from 'deprecated-react-native-prop-types';
 export default class DoubleTapView extends Component {
 
     static propTypes = {

--- a/PdfPageView.js
+++ b/PdfPageView.js
@@ -11,10 +11,9 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {
-    ViewPropTypes,
     requireNativeComponent,
 } from 'react-native';
-
+import {ViewPropTypes} from 'deprecated-react-native-prop-types';
 export default class PdfPageView extends PureComponent {
     _getStylePropsProps = () => {
         const {width, height} = this.props;

--- a/PdfView.js
+++ b/PdfView.js
@@ -8,8 +8,8 @@
 
 'use strict';
 import React, {Component} from 'react';
-import {ScrollView, FlatList, View, StyleSheet, ViewPropTypes} from 'react-native';
-
+import {ScrollView, FlatList, View, StyleSheet} from 'react-native';
+import {ViewPropTypes} from 'deprecated-react-native-prop-types';
 import PropTypes from 'prop-types';
 
 import PdfManager from './PdfManager';

--- a/PinchZoomView.js
+++ b/PinchZoomView.js
@@ -12,10 +12,9 @@ import PropTypes from 'prop-types';
 import {
     View,
     StyleSheet,
-    PanResponder,
-    ViewPropTypes,
+    PanResponder
 } from 'react-native';
-
+import {ViewPropTypes} from 'deprecated-react-native-prop-types';
 export default class PinchZoomView extends Component {
 
     static propTypes = {

--- a/index.js
+++ b/index.js
@@ -13,14 +13,13 @@ import {
     requireNativeComponent,
     View,
     Platform,
-    ViewPropTypes,
     StyleSheet,
     Image,
     Text
 } from 'react-native';
 
 import ReactNativeBlobUtil from 'react-native-blob-util'
-
+import {ViewPropTypes} from 'deprecated-react-native-prop-types';
 const SHA1 = require('crypto-js/sha1');
 import PdfView from './PdfView';
 


### PR DESCRIPTION
The error "Migrate to ViewPropTypes exported from 'deprecated-react-native-prop-types'." has been fixed.
The ViewPropTypes is now being imported from 'deprecated-react-native-prop-types'