### PR TITLE
Decode File Path in iOS

### DIFF
--- a/ios/RCTPdf/PdfManager.m
+++ b/ios/RCTPdf/PdfManager.m
@@ -50,7 +50,17 @@ RCT_EXPORT_METHOD(loadFile:(NSString *)path
 
     if (path != nil && path.length != 0) {
 
-        NSURL *pdfURL = [NSURL fileURLWithPath:path];
+        NSString *decodedPath = (__bridge_transfer NSString *)CFURLCreateStringByReplacingPercentEscapes(NULL, (CFStringRef)path, CFSTR(""));
+        
+        NSString *finalPath = NULL;
+        if (decodedPath == NULL) {
+            // use orignal provided path
+            finalPath = path;
+        } else {
+            finalPath = decodedPath;
+        }
+        
+        NSURL *pdfURL = [NSURL fileURLWithPath:finalPath];
         CGPDFDocumentRef pdfRef = CGPDFDocumentCreateWithURL((__bridge CFURLRef) pdfURL);
 
         if (pdfRef == NULL) {


### PR DESCRIPTION
### Why
We are unable to preview a PDF on iOS when the file name contains space or special characters: ( "my sample.pdf" or "mySample%20.pdf" ). 

Most widely used [react-native-document-picker](https://github.com/rnmods/react-native-document-picker) to select a file have also added in their [documentation](https://github.com/rnmods/react-native-document-picker#uri) , that users need to decode the file path. 

### Why only iOS?
As discussed in the issue #646   , the decoding is already handled in android by use of `URI.parse` method. Refer Android documentation for the same [here](https://developer.android.com/reference/android/net/Uri#parse(java.lang.String))

### Changes done
The changes include to decode the path in iOS as well. 

Failing to properly decode the path, I am adding fallback to use the provided orignial path string. 

### Issues
Resolves #488, resolves #646 

### References to help the reviewer
 
[CFURLCreateStringByReplacingPercentEscapes](https://developer.apple.com/documentation/corefoundation/1542938-cfurlcreatestringbyreplacingperc)