### PR TITLE
Ensure correct scale applied for fit policy on PDFs of irregular page sizes

### DIFF
--- a/ios/RCTPdf/RCTPdfView.m
+++ b/ios/RCTPdf/RCTPdfView.m
@@ -200,7 +200,7 @@ const float MIN_SCALE = 1.0f;
 
         if (_pdfDocument && ([changedProps containsObject:@"path"] || [changedProps containsObject:@"fitPolicy"] || [changedProps containsObject:@"minScale"] || [changedProps containsObject:@"maxScale"])) {
 
-            PDFPage *pdfPage = [_pdfDocument pageAtIndex:_pdfDocument.pageCount-1];
+            PDFPage *pdfPage = _pdfView.currentPage ? _pdfView.currentPage : [_pdfDocument pageAtIndex:_pdfDocument.pageCount-1];
             CGRect pdfPageRect = [pdfPage boundsForBox:kPDFDisplayBoxCropBox];
 
             // some pdf with rotation, then adjust it


### PR DESCRIPTION
Re: issue #583 

When loading a PDF with irregular page sizes, using the last page by default to calculate the scale factor can lead to the incorrect scale being applied to the initial page. See above issue for video demo of this.

This PR amends to measure the current page where possible, reverting to the existing behaviour if this is null. 

Resolves #583 