### PR TITLE
add deprecated-react-native-prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "url": "https://github.com/wonday/react-native-pdf/issues"
     },
     "dependencies": {
-        "crypto-js": "^3.2.0"
+        "crypto-js": "^3.2.0",
+        "deprecated-react-native-prop-types": "^2.3.0"
     },
     "devDependencies": {
         "prop-types": "^15.7.2"


### PR DESCRIPTION
Adding missing dependency deprecated-react-native-prop-types

<img width="305" alt="Screenshot 2022-07-02 at 21 46 31" src="https://user-images.githubusercontent.com/1678364/177015837-c731b683-c08b-4a12-8681-b5d65262b17a.png">
