### PR TITLE
Fix Show Blank PDF

### DIFF
--- a/ios/RCTPdf/RCTPdfView.m
+++ b/ios/RCTPdf/RCTPdfView.m
@@ -118,6 +118,7 @@ const float MIN_SCALE = 1.0f;
 
         if ([changedProps containsObject:@"path"]) {
 
+            _path = (__bridge_transfer NSString *)CFURLCreateStringByReplacingPercentEscapes(NULL, (CFStringRef)_path, CFSTR(""));
 
             if (_pdfDocument != Nil) {
                 //Release old doc

--- a/ios/RCTPdf/RCTPdfView.m
+++ b/ios/RCTPdf/RCTPdfView.m
@@ -118,7 +118,6 @@ const float MIN_SCALE = 1.0f;
 
         if ([changedProps containsObject:@"path"]) {
 
-            _path = (__bridge_transfer NSString *)CFURLCreateStringByReplacingPercentEscapes(NULL, (CFStringRef)_path, CFSTR(""));
 
             if (_pdfDocument != Nil) {
                 //Release old doc
@@ -133,6 +132,9 @@ const float MIN_SCALE = 1.0f;
                     _pdfDocument = [[PDFDocument alloc] initWithData:blobData];
                 }
             } else {
+            
+                // decode file path
+                _path = (__bridge_transfer NSString *)CFURLCreateStringByReplacingPercentEscapes(NULL, (CFStringRef)_path, CFSTR(""));
                 NSURL *fileURL = [NSURL fileURLWithPath:_path];
                 _pdfDocument = [[PDFDocument alloc] initWithURL:fileURL];
             }


### PR DESCRIPTION
**Why**
getting blank pdf while trying to load pdf which contains space or special characters ( file:///Users/Manan/Library/Developer/C9F05D30-8712-414E-ACBE-BBD37744D6A4/Library/Caches/9978C439-432B-4906-BB9E-4E074842C23A/Manan%20G.pdf)

the file path is getting from react-native-document-picker and we need to decode the file path. it's also mentioned in https://github.com/rnmods/react-native-document-picker#uri

**Issues**

https://github.com/wonday/react-native-pdf/issues/670 https://github.com/wonday/react-native-pdf/issues/646
