### PR TITLE
Fix typos

### DIFF
--- a/FabricExample/android/app/build.gradle
+++ b/FabricExample/android/app/build.gradle
@@ -281,7 +281,7 @@ dependencies {
 
 if (isNewArchitectureEnabled()) {
     // If new architecture is enabled, we let you build RN from source
-    // Otherwise we fallback to a prebuilt .aar bundled in the NPM package.
+    // Otherwise we fallback to a prebuilt .aar bundled in the npm package.
     // This will be applied to all the imported transtitive dependency.
     configurations.all {
         resolutionStrategy.dependencySubstitution {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # react-native-pdf
 [![npm](https://img.shields.io/npm/v/react-native-pdf.svg?style=flat-square)](https://www.npmjs.com/package/react-native-pdf)
 
-A react native PDF view component (cross-platform support)
+A React Native PDF view component (cross-platform support)
 
 ### Feature
 
@@ -180,7 +180,7 @@ v6.6.0 depresed
 1. Fixed: Migrate to ViewPropTypes exported from 'deprecated-react-native-prop-types'
 2. Added: Decode File Path for iOS
 3. Improved: prefer current page for calculating scale factor on fit
-4. Improved: Typescript version source
+4. Improved: TypeScript version source
 
 v6.5.0
 1. Fix: replace mavenCentral with maven
@@ -190,7 +190,7 @@ v6.5.0
 5. Remove: dependency to fbjs
 
 v6.4.0
-1. Remove sample for reducing NPM package size
+1. Remove sample for reducing npm package size
 2. Add support for setting a filename for the cached pdf file
 3. Use react-native-blob-util instead of rn-fetch-blob
 4. Add blob support

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "react-native-pdf",
     "version": "6.6.2",
-    "summary": "A react native PDF view component",
-    "description": "A react native PDF view component, support ios and android platform",
+    "summary": "A React Native PDF view component",
+    "description": "A React Native PDF view component (cross-platform support)",
     "main": "index.js",
     "typings": "./index.d.ts",
     "repository": {


### PR DESCRIPTION
A couple of minor typo fixes, e.g. `NPM` -> `npm` `Typescript` -> `TypeScript`.

Also synchronized the `description` field with what is stated in README.md:

> A React Native PDF view component (cross-platform support)