### PR TITLE
Update `build.gradle` to support RN 0.71 on new arch

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,15 +19,52 @@ repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$projectDir/../node_modules/react-native/android"
-        url 'https://jitpack.io'
         content {
             // Use Jitpack only for AndroidPdfViewer; the rest is hosted at mavenCentral.
             includeGroup "com.github.TalbotGooday"
         }
     }
+    maven { url 'https://jitpack.io' }
 }
 
 apply plugin: 'com.android.library'
+
+def resolveReactNativeDirectory() {
+    def reactNativeLocation = safeExtGet("REACT_NATIVE_NODE_MODULES_DIR", null)
+    if (reactNativeLocation != null) {
+        return file(reactNativeLocation)
+    }
+
+    // monorepo workaround
+    // react-native can be hoisted or in project's own node_modules
+    def reactNativeFromProjectNodeModules = file("${rootProject.projectDir}/../node_modules/react-native")
+    if (reactNativeFromProjectNodeModules.exists()) {
+        return reactNativeFromProjectNodeModules
+    }
+
+    def reactNativeFromNodeModulesWithPDF = file("${projectDir}/../../react-native")
+    if (reactNativeFromNodeModulesWithPDF.exists()) {
+        return reactNativeFromNodeModulesWithPDF
+    }
+
+    throw new Exception(
+            "[react-native-pdf] Unable to resolve react-native location in " +
+                    "node_modules. You should add project extension property (in app/build.gradle) " +
+                    "`REACT_NATIVE_NODE_MODULES_DIR` with path to react-native."
+    )
+}
+
+def getReactNativeMinorVersion() {
+    def REACT_NATIVE_DIR = resolveReactNativeDirectory()
+
+    def reactProperties = new Properties()
+    file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
+
+    def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
+    def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.startsWith("0.0.0-") ? 1000 : REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
+
+    return REACT_NATIVE_MINOR_VERSION
+}
 
 def isNewArchitectureEnabled() {
     // To opt-in for the New Architecture, you can either:
@@ -75,7 +112,7 @@ android {
 }
 
 dependencies {
-    if (isNewArchitectureEnabled()) {
+    if (isNewArchitectureEnabled() && getReactNativeMinorVersion() < 71) {
         implementation project(":ReactAndroid")
     } else {
         implementation 'com.facebook.react:react-native:+'


### PR DESCRIPTION
Since React Native 0.71, the binaries are distributed via maven instead of local `:ReactAndroid` project.