### PR TITLE
fix typo in RNPDFPdfViewManagerInterface interface causing android build crash

### DIFF
--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNPDFPdfViewManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNPDFPdfViewManagerDelegate.java
@@ -41,11 +41,11 @@ public class RNPDFPdfViewManagerDelegate<T extends View, U extends BaseViewManag
         mViewManager.setHorizontal(view, value == null ? false : (boolean) value);
         break;
       case "showsHorizontalScrollIndicator":
-        // mViewManager.setShowsHorizontalScrollIndicator(view, value == null ? false : (boolean) value);
+        mViewManager.setShowsHorizontalScrollIndicator(view, value == null ? false : (boolean) value);
         break;
       case "showsVerticalScrollIndicator":
-        // mViewManager.setShowsVerticalScrollIndicator(view, value == null ? false : (boolean) value);
-        break;    
+        mViewManager.setShowsVerticalScrollIndicator(view, value == null ? false : (boolean) value);
+        break;
       case "enablePaging":
         mViewManager.setEnablePaging(view, value == null ? false : (boolean) value);
         break;

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNPDFPdfViewManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNPDFPdfViewManagerInterface.java
@@ -19,8 +19,8 @@ public interface RNPDFPdfViewManagerInterface<T extends View> {
   void setMinScale(T view, float value);
   void setMaxScale(T view, float value);
   void setHorizontal(T view, boolean value);
-  void showsHorizontalScrollIndicator(T view, boolean value);
-  void showsVerticalScrollIndicator(T view, boolean value);
+  void setShowsHorizontalScrollIndicator(T view, boolean value);
+  void setShowsVerticalScrollIndicator(T view, boolean value);
   void setEnablePaging(T view, boolean value);
   void setEnableRTL(T view, boolean value);
   void setEnableAnnotationRendering(T view, boolean value);


### PR DESCRIPTION
fix typo which causing android build to crash with the following error message
 
```gradle
> Task :react-native-pdf:compileReleaseJavaWithJavac FAILED
/Users/runner/work/1/s/node_modules/react-native-pdf/android/src/main/java/org/wonday/pdf/PdfManager.java:29: error: PdfManager is not abstract and does not override abstract method showsVerticalScrollIndicator(PdfView,boolean) in RNPDFPdfViewManagerInterface
public class PdfManager extends SimpleViewManager<PdfView> implements RNPDFPdfViewManagerInterface<PdfView> {
       ^
/Users/runner/work/1/s/node_modules/react-native-pdf/android/src/main/java/org/wonday/pdf/PdfManager.java:97: error: method does not override or implement a method from a supertype
    @Override
    ^
/Users/runner/work/1/s/node_modules/react-native-pdf/android/src/main/java/org/wonday/pdf/PdfManager.java:102: error: method does not override or implement a method from a supertype
    @Override
    ^
Note: /Users/runner/work/1/s/node_modules/react-native-pdf/android/src/main/java/org/wonday/pdf/PdfView.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
3 errors
```