### PR TITLE
Exported PDF props (Update index.d.ts)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ export type Source = {
     method?: string;
 };
 
-interface Props {
+interface PdfProps {
     style?: ReactNative.StyleProp<ReactNative.ViewStyle>,
     source: Source | number,
     page?: number,
@@ -56,7 +56,7 @@ interface Props {
     onPressLink?: (url: string) => void,
 }
 
-declare class Pdf extends React.Component<Props, any> {
+declare class Pdf extends React.Component<PdfProps, any> {
     setPage: (pageNumber: number) => void;
 }
 


### PR DESCRIPTION
Export the props as well

Because I am creating a component that will show the pdf and I want it to extend the prop of the react-native-pdf but I am unable to access it


Therefore I exported