### PR TITLE
fix: bump crypto-js to avoid critical vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "url": "https://github.com/wonday/react-native-pdf/issues"
     },
     "dependencies": {
-        "crypto-js": "^3.2.0",
+        "crypto-js": "4.2.0",
         "deprecated-react-native-prop-types": "^2.3.0"
     },
     "devDependencies": {


### PR DESCRIPTION
### Description

Snyk has informed us of a critical vulnerability in the crypto-js package, which is used in the react-native-pdf dependencies. In order to prevent this vulnerability I have updated crypto-js to the latest version. 

For more details you can have a look at this snyk report: 

https://security.snyk.io/vuln/SNYK-JS-CRYPTOJS-6028119

### Closes

https://github.com/wonday/react-native-pdf/issues/779