### PR TITLE
fix(iOS): Fix double tap zoom scrolling

### DIFF
--- a/ios/RNPDFPdf/RNPDFPdfView.mm
+++ b/ios/RNPDFPdf/RNPDFPdfView.mm
@@ -74,6 +74,7 @@ const float MIN_SCALE = 1.0f;
     UITapGestureRecognizer *_singleTapRecognizer;
     UIPinchGestureRecognizer *_pinchRecognizer;
     UILongPressGestureRecognizer *_longPressRecognizer;
+    UITapGestureRecognizer *_doubleTapEmptyRecognizer;
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -187,6 +188,7 @@ using namespace facebook::react;
     [self removeGestureRecognizer:_singleTapRecognizer];
     [self removeGestureRecognizer:_pinchRecognizer];
     [self removeGestureRecognizer:_longPressRecognizer];
+    [self removeGestureRecognizer:_doubleTapEmptyRecognizer];
 
     [self initCommonProps];
 }
@@ -556,6 +558,7 @@ using namespace facebook::react;
     _singleTapRecognizer = nil;
     _pinchRecognizer = nil;
     _longPressRecognizer = nil;
+    _doubleTapEmptyRecognizer = nil;
 }
 
 #pragma mark notification process
@@ -686,6 +689,13 @@ using namespace facebook::react;
 }
 
 #pragma mark gesture process
+
+/**
+ *  Empty double tap handler
+ *
+ *
+ */
+- (void)handleDoubleTapEmpty:(UITapGestureRecognizer *)recognizer {}
 
 /**
  *  Tap
@@ -836,6 +846,12 @@ using namespace facebook::react;
     [self addGestureRecognizer:longPressRecognizer];
     _longPressRecognizer = longPressRecognizer;
 
+    // Override the _pdfView double tap gesture recognizer so that it doesn't confilict with custom double tap
+    UITapGestureRecognizer *doubleTapEmptyRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                                          action:@selector(handleDoubleTapEmpty:)];
+    doubleTapEmptyRecognizer.numberOfTapsRequired = 2;
+    [_pdfView addGestureRecognizer:doubleTapEmptyRecognizer];
+    _doubleTapEmptyRecognizer = doubleTapEmptyRecognizer;
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer


### PR DESCRIPTION
## Fix double tap zoom scrolling

The PR fixed an iOS issue where double-tapping to zoom in on a PDF with a scale greater than 1 caused a fast scrolling and only then zooming to the desired point (video attached). The reason behind is that the custom scrolling conflicts with the _pdfView gesture recognizers



<details>
  <summary>Video of the issue</summary>

  [Issue Video](https://github.com/wonday/react-native-pdf/assets/138074114/6aa826ff-45f5-44af-93a0-050b78e0dcc0)

</details>

<details>
  <summary>Video with the fixes</summary>

  [Fixed Video](https://github.com/wonday/react-native-pdf/assets/138074114/867ba1a5-a3bf-46f8-bd39-38c88200eaca)

</details>
