### PR TITLE
Corrected namespace to match package name in .java files

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -81,7 +81,7 @@ if (isNewArchitectureEnabled()) {
 android {
     def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
     if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
-        namespace "com.wonday.rnpdf"
+        namespace "org.wonday.pdf"
     }
     compileSdkVersion safeExtGet('compileSdkVersion', 31)
 


### PR DESCRIPTION
Fix #786