### PR TITLE
fix:package name missing pod install error

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.wonday.pdf">
 
 
 </manifest>


### PR DESCRIPTION
package name missing from androidManifest causes pod install error

https://github.com/wonday/react-native-pdf/issues/787