### PR TITLE
fix(Android): crash issue on pdf

### DIFF
--- a/index.js
+++ b/index.js
@@ -367,11 +367,18 @@ export default class Pdf extends Component {
                 message[4] = message.splice(4).join('|');
             }
             if (message[0] === 'loadComplete') {
+                let tableContents;
+                try {
+                    tableContents = message[4]&&JSON.parse(message[4]);
+                } catch(e) {
+                    tableContents = message[4];
+                }
                 this.props.onLoadComplete && this.props.onLoadComplete(Number(message[1]), this.state.path, {
                     width: Number(message[2]),
                     height: Number(message[3]),
                 },
-                message[4]&&JSON.parse(message[4]));
+                tableContents
+                );
             } else if (message[0] === 'pageChanged') {
                 this.props.onPageChanged && this.props.onPageChanged(Number(message[1]), Number(message[2]));
             } else if (message[0] === 'error') {


### PR DESCRIPTION
Fixes https://github.com/Expensify/App/issues/29743

This PR is fixing when we add this pdf [class-9-maths-chapter-10-solutions.pdf](https://github.com/Expensify/App/files/12927237/class-9-maths-chapter-10-solutions.pdf) its start crashing on content parse time.

<details>
<summary><b>Video before fixing</b></summary>


https://github.com/wonday/react-native-pdf/assets/16595846/967f2d16-41c5-4258-a2bd-cd42a4b23edb


</details>

<details>
<summary><b>Video after fixing</b></summary>

https://github.com/wonday/react-native-pdf/assets/16595846/849e386e-ce75-4da2-8b79-ab3a88d32916



</details>