### PR TITLE
Update underlying PDFium library on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.0")
+        classpath("com.android.tools.build:gradle:7.4.2")
     }
 }
 
@@ -21,9 +21,10 @@ repositories {
         url "$projectDir/../node_modules/react-native/android"
         content {
             // Use Jitpack only for AndroidPdfViewer; the rest is hosted at mavenCentral.
-            includeGroup "com.github.TalbotGooday"
+            includeGroup "com.github.Zacharee"
         }
     }
+    google()
     maven { url 'https://jitpack.io' }
 }
 
@@ -122,7 +123,8 @@ dependencies {
         implementation 'com.facebook.react:react-native:+'
     }
     // NOTE: The original repo at com.github.barteksc is abandoned by the maintainer; there will be no more updates coming from that repo.
-    //       It was taken over by com.github.TalbotGooday; from now on please use this repo until (if ever) the Barteksc repo is resumed.
-    implementation 'com.github.TalbotGooday:AndroidPdfViewer:3.1.0-beta.3'
+    // TalbotGooday is no longer updating their library either, and the underlying PDFium libraries were never updated.
+    // This dependency rebases the wrapper on PdfiumAndroidKt, which has much more recent native libraries.
+    implementation 'com.github.Zacharee:AndroidPdfViewer:3.2.0'
     implementation 'com.google.code.gson:gson:2.8.5'
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true

--- a/android/src/main/java/org/wonday/pdf/PdfView.java
+++ b/android/src/main/java/org/wonday/pdf/PdfView.java
@@ -11,23 +11,19 @@ package org.wonday.pdf;
 import java.io.File;
 
 import android.content.ContentResolver;
-import android.content.Context;
+import android.util.SizeF;
 import android.view.View;
 import android.view.ViewGroup;
 import android.util.Log;
-import android.graphics.PointF;
 import android.net.Uri;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.graphics.Canvas;
-import javax.annotation.Nullable;
-
 
 import com.github.barteksc.pdfviewer.PDFView;
 import com.github.barteksc.pdfviewer.listener.OnPageChangeListener;
 import com.github.barteksc.pdfviewer.listener.OnLoadCompleteListener;
 import com.github.barteksc.pdfviewer.listener.OnErrorListener;
-import com.github.barteksc.pdfviewer.listener.OnRenderListener;
 import com.github.barteksc.pdfviewer.listener.OnTapListener;
 import com.github.barteksc.pdfviewer.listener.OnDrawListener;
 import com.github.barteksc.pdfviewer.listener.OnPageScrollListener;
@@ -53,12 +49,8 @@ import static java.lang.String.format;
 
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.lang.ClassCastException;
 
-import com.shockwave.pdfium.PdfDocument;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.shockwave.pdfium.util.SizeF;
 
 public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompleteListener,OnErrorListener,OnTapListener,OnDrawListener,OnPageScrollListener, LinkHandler {
     private ThemedReactContext context;


### PR DESCRIPTION
TalbotGooday's library hasn't been updated since 2020, and the native PDFium libraries hadn't been updated since 2018.

https://github.com/johngray1965/PdfiumAndroidKt is a hard fork of PdfiumAndroid that converts the code to Kotlin, but also updates the native libraries to much more recent versions.

I forked TalbotGooday's AndroidPdfViewer library and rebased it to use PdfiumAndroidKt.

This PR changes the AndroidPdfViewer dependency to my fork and makes necessary changes for the project to compile.

Note: I changed a few other things to make syncing work properly, such as upgrading the Android Gradle Plugin.
