### PR TITLE
fix: Add missing 'enableDoubleTapZoom' to fabric codegen source

### DIFF
--- a/fabric/RNPDFPdfNativeComponent.js
+++ b/fabric/RNPDFPdfNativeComponent.js
@@ -22,6 +22,7 @@
    enablePaging: ?boolean,
    enableRTL: ?boolean,
    enableAnnotationRendering: ?boolean,
+   enableDoubleTapZoom: ?boolean,
    showsHorizontalScrollIndicator: ?boolean,
    showsVerticalScrollIndicator: ?boolean,
    enableAntialiasing: ?boolean,


### PR DESCRIPTION
This PR addresses #831 by adding the missing `enableDoubleTapZoom` to the codegen source file