### PR TITLE
fix: an issue that crashes when cancel is not present

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ export default class Pdf extends Component {
 
         if ((nextSource.uri !== curSource.uri)) {
             // if has download task, then cancel it.
-            if (this.lastRNBFTask) {
+            if (this.lastRNBFTask && this.lastRNBFTask.cancel) {
                 this.lastRNBFTask.cancel(err => {
                     this._loadFromSource(this.props.source);
                 });


### PR DESCRIPTION
I have a use case where the user swipes multiple pdf files, and when the pdf is still loading and user swipes it, the cancel function get fired before its initialized. I fixed it by checking if the cancel function exists before calling it.