### PR TITLE
fix: Prevent crashes when canceling download tasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,10 +129,12 @@ export default class Pdf extends Component {
 
         if ((nextSource.uri !== curSource.uri)) {
             // if has download task, then cancel it.
-            if (this.lastRNBFTask) {
-                this.lastRNBFTask.cancel(err => {
-                    this._loadFromSource(this.props.source);
-                });
+            if (this.lastRNBFTask ) {
+                if (typeof this.lastRNBFTask.cancel === 'function') {
+                    this.lastRNBFTask.cancel(err => {
+                        this._loadFromSource(this.props.source);
+                    });
+                }
                 this.lastRNBFTask = null;
             } else {
                 this._loadFromSource(this.props.source);
@@ -148,8 +150,10 @@ export default class Pdf extends Component {
     componentWillUnmount() {
         this._mounted = false;
         if (this.lastRNBFTask) {
-            // this.lastRNBFTask.cancel(err => {
-            // });
+            if (typeof this.lastRNBFTask.cancel === 'function') {
+                this.lastRNBFTask.cancel(err => {
+                });
+            }
             this.lastRNBFTask = null;
         }
 
@@ -253,8 +257,10 @@ export default class Pdf extends Component {
     _downloadFile = async (source, cacheFile) => {
 
         if (this.lastRNBFTask) {
-            this.lastRNBFTask.cancel(err => {
-            });
+            if (typeof this.lastRNBFTask.cancel === 'function') {
+                this.lastRNBFTask.cancel(err => {
+                });
+            }
             this.lastRNBFTask = null;
         }
 


### PR DESCRIPTION
### Description
This PR addresses a critical issue where the app crashes when attempting to cancel certain tasks within the PDF component. The crash occurs because the cancel method is called on `lastRNBFTask` without first checking if it is a function.

### Problem
When the component updates, unmounts, or when a new download is initiated, the app attempts to cancel any ongoing task represented by `lastRNBFTask`. However, if `lastRNBFTask.cancel` is not a function, this leads to an uncaught exception, causing the app to crash.

### Solution
Safety checks have been implemented to ensure that `lastRNBFTask.cancel` is a function before any attempt is made to call it. The existing checks for the presence of `lastRNBFTask` have been retained, and the cleanup behavior (setting `lastRNBFTask` to null) has been preserved.

### Screenshots
**componentDidUpdate**             |  **componentWillUnmount**
:-------------------------:|:-------------------------:
<img src="https://github.com/user-attachments/assets/fa3fcd68-a6d0-47be-996e-54b8b63143af" width="200px" /> | <img src="https://github.com/user-attachments/assets/fd06d863-0308-4429-9c32-04e0bed4e3ae" width="200px" />


