### PR TITLE
Fix PDF failed to load when the file URI contains an encoded accented character

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,7 +235,7 @@ export default class Pdf extends Component {
                 } else {
                     if (this._mounted) {
                        this.setState({
-                            path: unescape(uri.replace(/file:\/\//i, '')),
+                            path: decodeURIComponent(uri.replace(/file:\/\//i, '')),
                             isDownloaded: true,
                         });
                     }


### PR DESCRIPTION
The decoding of the URI is currently done using `unescape`.
https://github.com/wonday/react-native-pdf/blob/d545ff27b49850c773f6c443dfc65891881c0ed2/index.js#L238

However, this fails if the URI contains an encoded accented name, for example:

ù is encoded to `%C3%B9`, but decoding it using `unescape` gives `Ã¹`.

This PR replaces `unescape` with `decodeURIComponent`.