### PR TITLE
fix (#878)

### DIFF
--- a/fabric/RNPDFPdfNativeComponent.js
+++ b/fabric/RNPDFPdfNativeComponent.js
@@ -27,6 +27,7 @@
    showsVerticalScrollIndicator: ?boolean,
    scrollEnabled: ?boolean,
    enableAntialiasing: ?boolean,
+   enableDoubleTapZoom: ?boolean,
    fitPolicy: ?Int32,
    spacing: ?Int32,
    password: ?string,


### PR DESCRIPTION
:bug:  FIXED - No member named 'enableDoubleTapZoom' in 'facebook::react::RNPDFPdfViewProps' #878 