### PR TITLE
fix: dispatch event PdfView.java

### DIFF
--- a/android/src/main/java/org/wonday/pdf/PdfView.java
+++ b/android/src/main/java/org/wonday/pdf/PdfView.java
@@ -12,6 +12,8 @@ import java.io.File;
 
 import android.content.ContentResolver;
 import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.SizeF;
 import android.view.View;
 import android.view.ViewGroup;
@@ -105,7 +107,7 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
         TopChangeEvent tce = new TopChangeEvent(surfaceId, getId(), event);
 
         if (dispatcher != null) {
-            dispatcher.dispatchEvent(tce);
+            new Handler(Looper.getMainLooper()).postDelayed(() -> dispatcher.dispatchEvent(tce), 10);
         }
 
 //        ReactContext reactContext = (ReactContext)this.getContext();


### PR DESCRIPTION
loadComplete and onPageChanged seem to dispatch at the same time, a little delay to prevent that.

The discussion/issue about

https://github.com/wonday/react-native-pdf/issues/899