### PR TITLE
Fix not rendering on iOS - React-native 0.78

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
         "jsSrcsDir": "./fabric",
         "android": {
           "javaPackageName": "org.wonday.pdf"
+        },
+        "ios": {
+          "componentProvider": {
+            "RNPDFPdfView": "RNPDFPdfView"
+          }
         }
       }
 }


### PR DESCRIPTION
On react-native 0.78 iOS simulator & device pdf was not rendered.