### PR TITLE
Android 16 KB Page Size support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -126,6 +126,6 @@ dependencies {
     // The repo from zacharee is based on PdfiumAndroidKt, a much newer fork of PdfiumAndroid, with better maintenance and updated native libraries.
     implementation 'com.github.zacharee:AndroidPdfViewer:4.0.1'
     // Depend on PdfiumAndroidKt directly so this can be updated independently of AndroidPdfViewer as updates are provided.
-    implementation 'io.legere:pdfiumandroid:1.0.24'
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'io.legere:pdfiumandroid:1.0.32'
+    implementation 'com.google.code.gson:gson:2.13.1'
 }


### PR DESCRIPTION
Updates pdfiumandroid and gson dependencies on Android so that the react-native-pdf library is compliant with the 16 KB Page Size [requirement](https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html).

Note: This PR contributes back the existing [patch](https://github.com/wonday/react-native-pdf/issues/947#issuecomment-2999541826) from @abitling 🎩. 

Related issues:

* https://github.com/wonday/react-native-pdf/issues/934
* https://github.com/wonday/react-native-pdf/issues/947
* https://github.com/wonday/react-native-pdf/issues/948
