### PR TITLE
fix: crash issue in io.legere:pdfiumandroid that occurred due to multithreading.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -126,6 +126,6 @@ dependencies {
     // The repo from zacharee is based on PdfiumAndroidKt, a much newer fork of PdfiumAndroid, with better maintenance and updated native libraries.
     implementation 'com.github.zacharee:AndroidPdfViewer:4.0.1'
     // Depend on PdfiumAndroidKt directly so this can be updated independently of AndroidPdfViewer as updates are provided.
-    implementation 'io.legere:pdfiumandroid:1.0.32'
+    implementation 'io.legere:pdfiumandroid:1.0.33'
     implementation 'com.google.code.gson:gson:2.13.1'
 }


### PR DESCRIPTION
Fixed the crash issue in io.legere:pdfiumandroid that occurred due to multithreading.
Therefore, we need to upgrade the io.legere:pdfiumandroid library to version 1.0.33.