### PR TITLE
fix: `Loaded page is null` error when `bookmarks` is 0

### DIFF
--- a/android/src/main/java/org/wonday/pdf/PdfView.java
+++ b/android/src/main/java/org/wonday/pdf/PdfView.java
@@ -89,10 +89,6 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
     private int oldW = 0;
     private int oldH = 0;
 
-    private int totalPages = 0;
-    private int[] pagesArrays;
-    private int bookmarks = 0;
-
     public PdfView(Context context, AttributeSet set){
         super(context, set);
     }
@@ -287,35 +283,18 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
             this.drawPdf();
     }
 
+    private int getPdfPageCount(File pdfFile) throws IOException {
+        ParcelFileDescriptor fileDescriptor =
+                ParcelFileDescriptor.open(pdfFile, ParcelFileDescriptor.MODE_READ_ONLY);
+        PdfRenderer renderer = new PdfRenderer(fileDescriptor);
+        int pageCount = renderer.getPageCount();
+        renderer.close();
+        fileDescriptor.close();
+        return pageCount;
+    }
+
     public void drawPdf() {
         showLog(format("drawPdf path:%s %s", this.path, this.page));
-        File file = new File(this.path);
-
-         if (file.exists()) {
-             try {
-                 ParcelFileDescriptor fileDescriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
-                 PdfRenderer pdfRenderer = new PdfRenderer(fileDescriptor);
-                 this.totalPages = pdfRenderer.getPageCount();
-                 int[] pagesArrays = new int[this.totalPages];
-                 if (this.enableRTL) {
-                    if(this.page>0){
-                        this.page = Math.max(this.bookmarks-1, 0);
-                    }else{
-                        this.page=this.totalPages;
-                    }
-                    for (int i = totalPages-1; i>=0; i--) {
-                        pagesArrays[i] =totalPages-1- i;
-                    }
-                    this.pagesArrays = pagesArrays;
-
-                }else{
-                    this.pagesArrays = null;
-                    this.page = Math.max(this.bookmarks-1, 0);
-                }
-             } catch (IOException e) {
-                 Log.e("error", "error read PDF", e);
-             }
-         }
 
         if (this.path != null){
 
@@ -342,9 +321,7 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
                 configurator = this.fromUri(getURI(this.path));
             }
 
-            configurator
-                .pages(this.pagesArrays)
-                .defaultPage(this.page)
+            configurator.defaultPage(this.page-1)
                 .swipeHorizontal(this.horizontal)
                 .onPageChange(this)
                 .onLoad(this)
@@ -361,7 +338,24 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
                 .enableSwipe(!this.singlePage && this.scrollEnabled)
                 .enableDoubletap(!this.singlePage && this.enableDoubleTapZoom)
                 .enableAnnotationRendering(this.enableAnnotationRendering)
-                .linkHandler(this);
+                .linkHandler(this)
+            ;
+
+            if (enableRTL) {
+                try {
+                    int pageCount = getPdfPageCount(new File(this.path));
+                    int[] reversedPages = new int[pageCount];
+                    for (int i=0; i<pageCount; i++) {
+                        reversedPages[i] = pageCount-1 - i;
+                    }
+                    configurator.pages(reversedPages);
+                    if(this.page != 1){
+                        this.page = pageCount;
+                    }
+                } catch (IOException e) {
+                    Log.e("error", "error while reading PDF", e);
+                }
+            }
 
             if (this.singlePage) {
                 configurator.pages(this.page-1);
@@ -384,14 +378,12 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
 
     // page start from 1
     public void setPage(int page) {
-        this.page = page;
-        this.bookmarks = page;
+        this.page = Math.max(page, 1);
     }
 
-    public void setEnableRTL(boolean enableRTL){
-        this.enableRTL= enableRTL;
-
-     }
+    public void setEnableRTL(boolean enableRTL) {
+        this.enableRTL = enableRTL;
+    }
 
     public void setScale(float scale) {
         this.scale = scale;


### PR DESCRIPTION
~The last version (7.0.1) has a bug after the [RTL support PR](https://github.com/wonday/react-native-pdf/pull/914) has been merged~

~`this.bookmarks` can be 0 and setting the page to `bookmarks-1` (-1) caused~

```
Loaded page is null
```

~error~

Actually, the original RTL implementation was full of untested code and strange patterns. I fixed that and the current implementation should work as expected

Please don't merge PR without descriptions 🙏 I spend too much time fixing my app due to RTL bugs (I'm not using RTL at all)