### PR TITLE
Add support for border radius

### DIFF
--- a/ios/RNPDFPdf/RNPDFPdfView.mm
+++ b/ios/RNPDFPdf/RNPDFPdfView.mm
@@ -66,6 +66,7 @@ const float MIN_SCALE = 1.0f;
     RCTBridge *_bridge;
     PDFDocument *_pdfDocument;
     PDFView *_pdfView;
+    UIView *_pdfClipView;
     PDFOutline *root;
     float _fixScaleFactor;
     bool _initialed;
@@ -212,7 +213,8 @@ using namespace facebook::react;
 {
     // Fabric equivalent of `reactSetFrame` method
     [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
-    _pdfView.frame = CGRectMake(0, 0, layoutMetrics.frame.size.width, layoutMetrics.frame.size.height);
+    _pdfClipView.frame = CGRectMake(0, 0, layoutMetrics.frame.size.width, layoutMetrics.frame.size.height);
+    _pdfView.frame = _pdfClipView.bounds;
 
     NSMutableArray *mProps = [_changedProps mutableCopy];
     if (_initialed) {
@@ -223,7 +225,8 @@ using namespace facebook::react;
     [self didSetProps:mProps];
 
     if (self.layer.cornerRadius > 0) {
-      [self applyCornerRadius:_pdfView radius:self.layer.cornerRadius];
+      _pdfClipView.layer.cornerRadius = self.layer.cornerRadius;
+      _pdfClipView.layer.masksToBounds = YES;
     }
 }
 
@@ -281,8 +284,12 @@ using namespace facebook::react;
     _initialed = NO;
     _changedProps = NULL;
 
-    [self addSubview:_pdfView];
+    _pdfClipView = [[UIView alloc] initWithFrame:self.bounds];
+    _pdfClipView.backgroundColor = [UIColor clearColor];
+    _pdfClipView.clipsToBounds = YES;
 
+    [self addSubview:_pdfClipView];
+    [_pdfClipView addSubview:_pdfView];
 
     // register notification
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
@@ -536,35 +543,16 @@ using namespace facebook::react;
         }
 
         _pdfView.backgroundColor = [UIColor clearColor];
-        if (self.layer.cornerRadius > 0) {
-          [self applyCornerRadius:_pdfView radius:self.layer.cornerRadius];
-        }
-
         [_pdfView layoutDocumentView];
         [self setNeedsDisplay];
     }
 }
 
-- (void)applyCornerRadius:(UIView *)view radius:(CGFloat)radius {
-  view.layer.cornerRadius = self.layer.cornerRadius;
-  view.layer.masksToBounds = YES;
-
-  // Recursively apply the corner radius to the subviews, otherwise those will take precendence
-  if ([view isKindOfClass:[UIScrollView class]]) {
-    view.layer.cornerRadius = radius;
-    view.layer.masksToBounds = YES;
-    view.clipsToBounds = YES;
-  }
-
-  for (UIView *subview in view.subviews) {
-    [self applyCornerRadius:subview radius:radius];
-  }
-}
-
 - (void)reactSetFrame:(CGRect)frame
 {
     [super reactSetFrame:frame];
-    _pdfView.frame = CGRectMake(0, 0, frame.size.width, frame.size.height);
+    _pdfClipView.frame = CGRectMake(0, 0, frame.size.width, frame.size.height);
+    _pdfView.frame = _pdfClipView.bounds;
 
     NSMutableArray *mProps = [_changedProps mutableCopy];
     if (_initialed) {
@@ -575,7 +563,8 @@ using namespace facebook::react;
     [self didSetProps:mProps];
 
     if (self.layer.cornerRadius > 0) {
-      [self applyCornerRadius:_pdfView radius:self.layer.cornerRadius];
+      _pdfClipView.layer.cornerRadius = self.layer.cornerRadius;
+      _pdfClipView.layer.masksToBounds = YES;
     }
 }
 
@@ -596,6 +585,7 @@ using namespace facebook::react;
 
     _pdfDocument = Nil;
     _pdfView = Nil;
+    _pdfClipView = Nil;
 
     //Remove notifications
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"PDFViewDocumentChangedNotification" object:nil];


### PR DESCRIPTION
### What?

Adds support for `styles.borderRadius` to the `PdfView` component.

- [x] iOS
- [x] Android (no changes required - android already supports border radius)

### Motivation

First of all, thank you @wonday and everyone else for maintaining this library — it has been extremely helpful.

In one of my apps, I needed to render the PDF view inside a rounded container (e.g. a card UI). However, I think [PdfView](https://developer.apple.com/documentation/pdfkit/pdfview) currently does not support rounded corners on iOS due to how PDFKit renders its content. 

### How?

#### iOS
Internally, [PDFView](https://developer.apple.com/documentation/pdfkit/pdfview) (which is the native impl. of the renderer this lib uses on iOS) manages a UIScrollView for page rendering. Applying a corner radius directly to the PDFView on its own does not fully work as you'd have to recursively apply the same radius to the UIScrollView internal views, but that does not quite work when scrolling as the pages are lazily rendered - resulting in wonky rounded pages some of the times.

<details><summary>Note: I had initially verified the above using this snippet via <a href="https://github.com/wonday/react-native-pdf/pull/993/commits/d9e0714379591801faa2b7fccffdd882b7d76244">https://github.com/wonday/react-native-pdf/pull/993/commits/d9e0714379591801faa2b7fccffdd882b7d76244</a></summary>
<pre lang="objective-c">
- (void)applyCornerRadius:(UIView *)view radius:(CGFloat)radius {
	view.layer.cornerRadius = self.layer.cornerRadius;
	view.layer.masksToBounds = YES;
	
	// Recursively apply the corner radius to the subviews, otherwise those will take precendence
	if ([view isKindOfClass:[UIScrollView class]]) {
		view.layer.cornerRadius = radius;
		view.layer.masksToBounds = YES;
		view.clipsToBounds = YES;
	}

	for (UIView *subview in view.subviews) {
		[self applyCornerRadius:subview radius:radius];
    }
}
</pre>
</details> 

So I decided to wrap the PDFView in a dedicated clipping container instead, which is then responsible for applying the corner radius and clip its child view, which in this case is PdfView.

| iOS |
|--------|
| <video src="https://github.com/user-attachments/assets/f359a147-582f-4062-b957-80e10059dca6" /> | 

#### Android

Setting border radius in android already works in this library which is great! So nothing changes in this end.

| Android (no changes needed) |
|--------|
| <video src="https://github.com/user-attachments/assets/a0439041-083a-4f83-b661-0498417a55b1" /> | 

---

PS: If you have any other suggestions, I’d love to hear them and will gladly take them on board.

Cheers,
Kishan