### PR TITLE
Android: preserve PDF callback events under Fabric , disable coalescing for shared PDF events 

### DIFF
--- a/android/src/main/java/org/wonday/pdf/events/TopChangeEvent.java
+++ b/android/src/main/java/org/wonday/pdf/events/TopChangeEvent.java
@@ -18,6 +18,11 @@ public class TopChangeEvent extends Event<TopChangeEvent> {
         return "topChange";
     }
 
+    @Override
+    public boolean canCoalesce() {
+        return false;
+    }
+
     @Nullable
     @Override
     protected WritableMap getEventData() {


### PR DESCRIPTION

## Summary

This change makes Android `TopChangeEvent` non-coalescible in `react-native-pdf`.
fixing : https://github.com/wonday/react-native-pdf/issues/1009

## Problem

`PdfView.loadComplete(...)` and `PdfView.onPageChanged(...)` both dispatch through the same `TopChangeEvent` / `topChange` path.

Under Fabric, `TopChangeEvent` inherits React Native's default coalescing behavior. Because both callbacks share the same event type for the same view, a later `pageChanged` event can replace an earlier `loadComplete` event before JS receives it.

The result is that native Android successfully loads the PDF, but JS sometimes never receives `onLoadComplete`.

## Root cause

- `PdfView.java` dispatches both `loadComplete|...` and `pageChanged|...` through `TopChangeEvent`
- `TopChangeEvent.java` always uses the same event name, `topChange`
- `fabric/RNPDFPdfNativeComponent.js` exposes one bubbling event prop, `onChange`
- `TopChangeEvent` does not override `canCoalesce()`, so Fabric may merge these events

## Fix

Override `canCoalesce()` in `TopChangeEvent` and return `false`.

That preserves both native callbacks in JS without changing the JS API or adding an app-level workaround.

## Why this approach

- minimal change
- preserves the current event contract
- fixes the event loss at the library layer
- avoids relying on downstream workarounds such as treating `onPageChanged` as a substitute for `onLoadComplete`

## Testing

Validated locally with temporary tracing:

- before this change:
  - native emitted `loadComplete`
  - native emitted `pageChanged`
  - JS only received `pageChanged`
- after this change:
  - JS received `loadComplete`
  - JS then received `pageChanged`

This also restored the downstream flow that depended on `onLoadComplete` firing reliably.

## Notes

If team prefer, I can also follow this up with a larger refactor that splits these callback types into distinct Fabric/native events.

Fixes #1009
