### PR TITLE
feat(file-transform-support): use blob-util's transform file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,25 @@ const styles = StyleSheet.create({
 
 ```
 
+#### Enabling transformFile
+
+If the pdf file needs to be transformed before it is displayed (e.g. when the stored or downloaded file is encrypted), set the `transformFile` prop to `true`. The transformation itself is performed by `react-native-blob-util`, so you must set a file transformer on that library first — see [setting a file transformer](https://github.com/RonRadtke/react-native-blob-util/#setting-a-file-transformer) in the `react-native-blob-util` documentation.
+
+```js
+<Pdf
+    source={source}
+    transformFile={true}
+    onLoadComplete={(numberOfPages,filePath) => {
+        console.log(`Number of pages: ${numberOfPages}`);
+    }}
+    onError={(error) => {
+        console.log(error);
+    }}
+    style={styles.pdf}/>
+```
+
+Note: when `transformFile` is enabled, the transformed file is written to a separate `.view` file, so the original file on disk stays in its transformed (e.g. encrypted) form.
+
 
 ### Configuration
 
@@ -367,6 +386,7 @@ const styles = StyleSheet.create({
 | enableDoubleTapZoom            |                             bool                              |           true           | Enable double tap to zoom gesture                                                                                                                                             | ✔   | ✔       | ✖                           | 6.8.0                    |
 | trustAllCerts                  |                             bool                              |           true           | Allow connections to servers with self-signed certification                                                                                                                   | ✔   | ✔       | ✖                           | 6.0.?                    |
 | singlePage                     |                             bool                              |          false           | Only show first page, useful for thumbnail views                                                                                                                              | ✔   | ✔       | ✔                           | 6.2.1                    |
+| transformFile                  |                             bool                              |          false           | Transform the pdf file with the file transformer set on `react-native-blob-util` before displaying it (e.g. to display an encrypted pdf). Requires a file transformer, see [setting a file transformer](https://github.com/RonRadtke/react-native-blob-util/#setting-a-file-transformer) | ✔   | ✔       | ✖                           | 7.0.6                    |
 | onLoadProgress                 |                       function(percent)                       |           null           | callback when loading, return loading progress (0-1)                                                                                                                          | ✔   | ✔       | ✖                           | <3.0                     |
 | onLoadComplete                 | function(numberOfPages, path, {width, height}, tableContents) |           null           | callback when pdf load completed, return total page count, pdf local/cache path, {width,height} and table of contents                                                         | ✔   | ✔       | ✔ but without tableContents | <3.0                     |
 | onPageChanged                  |                 function(page,numberOfPages)                  |           null           | callback when page changed ,return current page and total page count                                                                                                          | ✔   | ✔       | ✔                           | <3.0                     |

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,6 +71,7 @@ export interface PdfProps {
     fitPolicy?: 0 | 1 | 2,
     trustAllCerts?: boolean,
     singlePage?: boolean,
+    transformFile?: boolean,
     onLoadProgress?: (percent: number,) => void,
     onLoadComplete?: (numberOfPages: number, path: string, size: {height: number, width: number}, tableContents?: TableContent[]) => void,
     onPageChanged?: (page: number, numberOfPages: number) => void,

--- a/index.js
+++ b/index.js
@@ -163,7 +163,15 @@ export default class Pdf extends Component {
         }
 
         if (!this.props.cache) {
-            this._unlinkFile(this.state.path);
+            if (this.props.transformFile) {
+                // this.state.path is the .view file; unlink the original pre-transformed file.
+                // The .view file is cleaned up by _cleanupViewFile below.
+                if (this.lastPreTransformedPath) {
+                    this._unlinkFile(this.lastPreTransformedPath);
+                }
+            } else {
+                this._unlinkFile(this.state.path);
+            }
         }
 
         this._cleanupViewFile();
@@ -183,6 +191,7 @@ export default class Pdf extends Component {
         const base64 = await ReactNativeBlobUtil.fs.readFileWithTransform(preTransformedPath, 'base64');
         await ReactNativeBlobUtil.fs.writeFile(viewFile, base64, 'base64');
         this.lastViewFile = viewFile;
+        this.lastPreTransformedPath = preTransformedPath;
         return viewFile;
     };
 

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ export default class Pdf extends Component {
         fitPolicy: PropTypes.number,
         trustAllCerts: PropTypes.bool,
         singlePage: PropTypes.bool,
+        transformFile: PropTypes.bool,
         onLoadComplete: PropTypes.func,
         onPageChanged: PropTypes.func,
         onError: PropTypes.func,
@@ -95,6 +96,7 @@ export default class Pdf extends Component {
         trustAllCerts: true,
         usePDFKit: true,
         singlePage: false,
+        transformFile: false,
         onLoadProgress: (percent) => {
         },
         onLoadComplete: (numberOfPages, path) => {
@@ -124,7 +126,7 @@ export default class Pdf extends Component {
         };
 
         this.lastRNBFTask = null;
-
+        this.lastViewFile = null;
     }
 
     componentDidUpdate(prevProps) {
@@ -136,10 +138,12 @@ export default class Pdf extends Component {
             // if has download task, then cancel it.
             if (this.lastRNBFTask && this.lastRNBFTask.cancel) {
                 this.lastRNBFTask.cancel(err => {
+                    this._cleanupViewFile();
                     this._loadFromSource(this.props.source);
                 });
                 this.lastRNBFTask = null;
             } else {
+                this._cleanupViewFile();
                 this._loadFromSource(this.props.source);
             }
         }
@@ -158,7 +162,29 @@ export default class Pdf extends Component {
             this.lastRNBFTask = null;
         }
 
+        if (!this.props.cache) {
+            this._unlinkFile(this.state.path);
+        }
+
+        this._cleanupViewFile();
+
     }
+
+    _cleanupViewFile = () => {
+        if (this.lastViewFile) {
+            this._unlinkFile(this.lastViewFile);
+            this.lastViewFile = null;
+        }
+    };
+
+    _transformToViewFile = async (preTransformedPath) => {
+        const viewFile = preTransformedPath + '.view';
+        this._unlinkFile(viewFile);
+        const base64 = await ReactNativeBlobUtil.fs.readFileWithTransform(preTransformedPath, 'base64');
+        await ReactNativeBlobUtil.fs.writeFile(viewFile, base64, 'base64');
+        this.lastViewFile = viewFile;
+        return viewFile;
+    };
 
     _loadFromSource = (newSource) => {
 
@@ -175,10 +201,17 @@ export default class Pdf extends Component {
         if (source.cache) {
             ReactNativeBlobUtil.fs
                 .stat(cacheFile)
-                .then(stats => {
+                .then(async stats => {
                     if (!Boolean(source.expiration) || (source.expiration * 1000 + stats.lastModified) > (new Date().getTime())) {
-                        if (this._mounted) {
-                            this.setState({path: cacheFile, isDownloaded: true});
+                        try {
+                            const finalPath = this.props.transformFile
+                                ? await this._transformToViewFile(cacheFile)
+                                : cacheFile;
+                            if (this._mounted) {
+                                this.setState({path: finalPath, isDownloaded: true});
+                            }
+                        } catch (e) {
+                            this._onError(e);
                         }
                     } else {
                         // cache expirated then reload it
@@ -239,10 +272,25 @@ export default class Pdf extends Component {
                         });
                 } else {
                     if (this._mounted) {
-                       this.setState({
-                            path: decodeURIComponent(uri.replace(/file:\/\//i, '')),
-                            isDownloaded: true,
-                        });
+                      const localPath = decodeURIComponent(uri.replace(/file:\/\//i, ''));
+                      if (this.props.transformFile) {
+                          try {
+                              const viewFile = await this._transformToViewFile(localPath);
+                              if (this._mounted) {
+                                  this.setState({
+                                      path: viewFile,
+                                      isDownloaded: true,
+                                  });
+                              }
+                          } catch (e) {
+                              this._onError(e);
+                          }
+                      } else {
+                          this.setState({
+                              path: localPath,
+                              isDownloaded: true,
+                          });
+                      }
                     }
                 }
             } else {
@@ -270,6 +318,7 @@ export default class Pdf extends Component {
             // response data will be saved to this path if it has access right.
             path: tempCacheFile,
             trusty: this.props.trustAllCerts,
+            transformFile: !!this.props.transformFile,
         })
             .fetch(
                 source.method ? source.method : 'GET',
@@ -293,7 +342,7 @@ export default class Pdf extends Component {
 
                 this.lastRNBFTask = null;
 
-                if (res && res.respInfo && res.respInfo.headers && !res.respInfo.headers["Content-Encoding"] && !res.respInfo.headers["Transfer-Encoding"] && res.respInfo.headers["Content-Length"]) {
+                if (!this.props.transformFile && res && res.respInfo && res.respInfo.headers && !res.respInfo.headers["Content-Encoding"] && !res.respInfo.headers["Transfer-Encoding"] && res.respInfo.headers["Content-Length"]) {
                     const expectedContentLength = res.respInfo.headers["Content-Length"];
                     let actualContentLength;
 
@@ -317,11 +366,19 @@ export default class Pdf extends Component {
                 this._unlinkFile(cacheFile);
                 ReactNativeBlobUtil.fs
                     .cp(tempCacheFile, cacheFile)
-                    .then(() => {
-                        if (this._mounted) {
-                            this.setState({path: cacheFile, isDownloaded: true, progress: 1});
+                    .then(async () => {
+                        try {
+                            const finalPath = this.props.transformFile
+                                ? await this._transformToViewFile(cacheFile)
+                                : cacheFile;
+                            if (this._mounted) {
+                                this.setState({path: finalPath, isDownloaded: true, progress: 1});
+                            }
+                            this._unlinkFile(tempCacheFile);
+                        } catch (e) {
+                            this._unlinkFile(tempCacheFile);
+                            this._onError(e);
                         }
-                        this._unlinkFile(tempCacheFile);
                     })
                     .catch(async (error) => {
                         throw error;
@@ -365,7 +422,7 @@ export default class Pdf extends Component {
                 page: pageNumber
             });
           }
-        
+
     }
 
     _onChange = (event) => {


### PR DESCRIPTION
Follow up on https://github.com/wonday/react-native-pdf/issues/1016

Context:
- Underlying library react-native-blob-util provides support for transforming files this can be used
- This provides on-device file encryption/decryption for sensitive files
- This also can be used other use cases depending on projects outside of encryption scope

Implementation:
- introduce new prop boolean `transformFile`
- if false, same as current behaviour
- true, it uses transform upon read/write during blob-util operations, handles cleanup of decrypted file on unmount

Side thoughts:
- perhaps an alternative approach can be transformFileWrite / transformFileRead, so this can optionally be enabled per write/read basis, up for suggestions around that, I found it unnecessary since android/ios implementations of transform of blob-util has to be written explicitly anyways
- I also included a cleanup for non cached files upon unmount, can remove it if not desired, but this library currently does not ever clean up cache files over long term itself, which is piling up in device storage, this should solve fraction of that problem for non cached ones at low cost.

Security risks:
- For decrypted view file, if application crashes or closes during viewing the PDF, unless the same file is opened again, the view file is going to linger
- Perhaps at a separate PR (to keep this one simple), it can be looked at to clean all `.pdf.view` files on mount for security purposes, but maybe naming can be more specific to library such as `.pdf.rnpdfcache` instead of `.pdf.view` so there is no mistakenly deletion of other stuff 

----

~~I didn't edit README yet on how to use this in case requirements change or you want to write it yourself.~~

edit: README extended as per further discussion