### PR TITLE
fix(download): await temp-file unlink + cp() to stop ENOENT race + un…

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,80 +258,79 @@ export default class Pdf extends Component {
     _downloadFile = async (source, cacheFile) => {
 
         if (this.lastRNBFTask) {
-            this.lastRNBFTask.cancel(err => {
-            });
+            try {
+                this.lastRNBFTask.cancel(err => {
+                });
+            } catch (e) {
+                // ignore — cancel can fail if the task already settled
+            }
             this.lastRNBFTask = null;
         }
 
         const tempCacheFile = cacheFile + '.tmp';
-        this._unlinkFile(tempCacheFile);
+        // Await the unlink: the previous fire-and-forget call let ReactNativeBlobUtil's
+        // open(path) race with the in-flight delete on Android 14 + New Architecture and
+        // surface as `ENOENT (No such file or directory)` on the temp file. See #1018.
+        await this._unlinkFile(tempCacheFile);
 
-        this.lastRNBFTask = ReactNativeBlobUtil.config({
-            // response data will be saved to this path if it has access right.
-            path: tempCacheFile,
-            trusty: this.props.trustAllCerts,
-        })
-            .fetch(
-                source.method ? source.method : 'GET',
-                source.uri,
-                source.headers ? source.headers : {},
-                source.body ? source.body : ""
-            )
-            // listen to download progress event
-            .progress((received, total) => {
-                this.props.onLoadProgress && this.props.onLoadProgress(received / total);
-                if (this._mounted) {
-                    this.setState({progress: received / total});
-                }
+        try {
+            this.lastRNBFTask = ReactNativeBlobUtil.config({
+                // response data will be saved to this path if it has access right.
+                path: tempCacheFile,
+                trusty: this.props.trustAllCerts,
             })
-            .catch(async (error) => {
-                this._onError(error);
-            });
+                .fetch(
+                    source.method ? source.method : 'GET',
+                    source.uri,
+                    source.headers ? source.headers : {},
+                    source.body ? source.body : ""
+                )
+                // listen to download progress event
+                .progress((received, total) => {
+                    this.props.onLoadProgress && this.props.onLoadProgress(received / total);
+                    if (this._mounted) {
+                        this.setState({progress: received / total});
+                    }
+                });
 
-        this.lastRNBFTask
-            .then(async (res) => {
+            const res = await this.lastRNBFTask;
+            this.lastRNBFTask = null;
 
-                this.lastRNBFTask = null;
+            if (res && res.respInfo && res.respInfo.headers && !res.respInfo.headers["Content-Encoding"] && !res.respInfo.headers["Transfer-Encoding"] && res.respInfo.headers["Content-Length"]) {
+                const expectedContentLength = res.respInfo.headers["Content-Length"];
+                let actualContentLength;
 
-                if (res && res.respInfo && res.respInfo.headers && !res.respInfo.headers["Content-Encoding"] && !res.respInfo.headers["Transfer-Encoding"] && res.respInfo.headers["Content-Length"]) {
-                    const expectedContentLength = res.respInfo.headers["Content-Length"];
-                    let actualContentLength;
+                try {
+                    const fileStats = await ReactNativeBlobUtil.fs.stat(res.path());
 
-                    try {
-                        const fileStats = await ReactNativeBlobUtil.fs.stat(res.path());
-
-                        if (!fileStats || !fileStats.size) {
-                            throw new Error("FileNotFound:" + source.uri);
-                        }
-
-                        actualContentLength = fileStats.size;
-                    } catch (error) {
-                        throw new Error("DownloadFailed:" + source.uri);
+                    if (!fileStats || !fileStats.size) {
+                        throw new Error("FileNotFound:" + source.uri);
                     }
 
-                    if (expectedContentLength != actualContentLength) {
-                        throw new Error("DownloadFailed:" + source.uri);
-                    }
+                    actualContentLength = fileStats.size;
+                } catch (error) {
+                    throw new Error("DownloadFailed:" + source.uri);
                 }
 
-                this._unlinkFile(cacheFile);
-                ReactNativeBlobUtil.fs
-                    .cp(tempCacheFile, cacheFile)
-                    .then(() => {
-                        if (this._mounted) {
-                            this.setState({path: cacheFile, isDownloaded: true, progress: 1});
-                        }
-                        this._unlinkFile(tempCacheFile);
-                    })
-                    .catch(async (error) => {
-                        throw error;
-                    });
-            })
-            .catch(async (error) => {
-                this._unlinkFile(tempCacheFile);
-                this._unlinkFile(cacheFile);
-                this._onError(error);
-            });
+                if (expectedContentLength != actualContentLength) {
+                    throw new Error("DownloadFailed:" + source.uri);
+                }
+            }
+
+            await this._unlinkFile(cacheFile);
+            // Await the copy: the previous fire-and-forget chain swallowed cp() rejections
+            // as `Uncaught (in promise)` instead of forwarding them through onError.
+            await ReactNativeBlobUtil.fs.cp(tempCacheFile, cacheFile);
+            if (this._mounted) {
+                this.setState({path: cacheFile, isDownloaded: true, progress: 1});
+            }
+            await this._unlinkFile(tempCacheFile);
+        } catch (error) {
+            this.lastRNBFTask = null;
+            await this._unlinkFile(tempCacheFile);
+            await this._unlinkFile(cacheFile);
+            this._onError(error);
+        }
 
     };
 


### PR DESCRIPTION
Fixes #1018.

## Summary

`_downloadFile` had two latent bugs that surface together on Android 14 + New Architecture. Rewriting the function with proper `async/await` throughout closes both — no public API change.

## Root cause

**1. ENOENT race on `.pdf.tmp`**

The pre-fetch cleanup was fire-and-forget:

```js
const tempCacheFile = cacheFile + '.tmp';
this._unlinkFile(tempCacheFile);   // returns a Promise, not awaited

this.lastRNBFTask = ReactNativeBlobUtil.config({ path: tempCacheFile, ... }).fetch(...)
```

`_unlinkFile` is `async`, so the deletion of `tempCacheFile` runs concurrently with the native `open(path)` inside `ReactNativeBlobUtil.fetch`. On Android 14 + New Architecture the timing flips and `open` lands while the file is mid-delete, surfacing as:

```
Error: /data/user/0/<pkg>/cache/<sha1>.pdf.tmp: open failed: ENOENT (No such file or directory)
```

**2. Uncaught rejection bypassing `onError`**

The success path was structured as:

```js
this.lastRNBFTask = config().fetch().progress().catch(handler);
this.lastRNBFTask
    .then(async (res) => {
        ...
        ReactNativeBlobUtil.fs.cp(tempCacheFile, cacheFile)   // not awaited
            .then(() => { ... })
            .catch(async (error) => { throw error });          // re-throw escapes
    })
    .catch(...);
```

The inner `cp(...).then(...).catch(err => { throw err })` is never awaited from the outer `.then`. Any `cp` rejection re-thrown from the inner `.catch` becomes an unhandled promise rejection instead of propagating to the outer `.catch` → `_onError` is never called → the `onError` prop never fires.

## Fix

Rewrite `_downloadFile` with `async/await` throughout — single try/catch covering the whole flow:

- `await` the temp-file unlink **before** starting the fetch (closes the ENOENT race)
- `await` the fetch, `stat` check, `cacheFile` unlink, and `cp` into the final location, all inside one `try`
- Single `catch` cleans up both temp + final files and calls `_onError` exactly once

`this.lastRNBFTask` is still assigned to the in-flight fetch task before `await`, so the cancellation paths in `setNativeProps` / `componentWillUnmount` still find a cancellable task.

## API impact

None. Public component API unchanged. No new dependencies.

## Test plan

- [ ] Android 14 (API 34) with `newArchEnabled=true` — `<Pdf source={{ uri: '<remote-url>', cache: true }} />` on fresh install no longer crashes with `ENOENT`
- [ ] Forced network failure (airplane mode / 404 URL) → error flows through the `onError` prop (was: escaped as `Uncaught (in promise)`)
- [ ] Android 13 + old architecture — no regression
- [ ] iOS — no regression (this path is shared, but the bug only manifested on Android)
- [ ] Repeated unmount/remount mid-download — `cancel()` still aborts the fetch correctly

Syntax verified locally via `node --check index.js`.