### PR TITLE
fix: expose download HTTP status in onError

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,10 @@ export type Source = {
     method?: string;
 };
 
+export type PdfError = Error & {
+    status?: number;
+};
+
 export type TextSelectionChangeEvent = {
   nativeEvent:
     | {
@@ -74,7 +78,7 @@ export interface PdfProps {
     onLoadProgress?: (percent: number,) => void,
     onLoadComplete?: (numberOfPages: number, path: string, size: {height: number, width: number}, tableContents?: TableContent[]) => void,
     onPageChanged?: (page: number, numberOfPages: number) => void,
-    onError?: (error: object) => void,
+    onError?: (error: PdfError) => void,
     onPageSingleTap?: (page: number, x: number, y: number) => void,
     onScaleChanged?: (scale: number) => void,
     onPressLink?: (url: string) => void,

--- a/index.js
+++ b/index.js
@@ -292,9 +292,14 @@ export default class Pdf extends Component {
             .then(async (res) => {
 
                 this.lastRNBFTask = null;
+                const responseInfo = res ? res.respInfo : undefined;
 
-                if (res && res.respInfo && res.respInfo.headers && !res.respInfo.headers["Content-Encoding"] && !res.respInfo.headers["Transfer-Encoding"] && res.respInfo.headers["Content-Length"]) {
-                    const expectedContentLength = res.respInfo.headers["Content-Length"];
+                if (responseInfo && typeof responseInfo.status === "number" && (responseInfo.status < 200 || responseInfo.status >= 300)) {
+                    throw this._createDownloadError(source.uri, responseInfo);
+                }
+
+                if (responseInfo && responseInfo.headers && !responseInfo.headers["Content-Encoding"] && !responseInfo.headers["Transfer-Encoding"] && responseInfo.headers["Content-Length"]) {
+                    const expectedContentLength = responseInfo.headers["Content-Length"];
                     let actualContentLength;
 
                     try {
@@ -306,11 +311,11 @@ export default class Pdf extends Component {
 
                         actualContentLength = fileStats.size;
                     } catch (error) {
-                        throw new Error("DownloadFailed:" + source.uri);
+                        throw this._createDownloadError(source.uri, responseInfo);
                     }
 
                     if (expectedContentLength != actualContentLength) {
-                        throw new Error("DownloadFailed:" + source.uri);
+                        throw this._createDownloadError(source.uri, responseInfo);
                     }
                 }
 
@@ -333,6 +338,14 @@ export default class Pdf extends Component {
                 this._onError(error);
             });
 
+    };
+
+    _createDownloadError = (uri, responseInfo) => {
+        const error = new Error("DownloadFailed:" + uri);
+        if (responseInfo) {
+            error.status = responseInfo.status;
+        }
+        return error;
     };
 
     _unlinkFile = async (file) => {


### PR DESCRIPTION
## Summary
- fail PDF downloads when the HTTP response status is outside the 2xx range
- attach the response status to the emitted download error
- type onError with a new PdfError type exposing optional status

Fixes #493.

## Validation
- node --check index.js
- npm pack --dry-run