### PR TITLE
fix: avoid loading legacy PdfView on Fabric path

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,14 +21,22 @@ import PdfViewNativeComponent, {
     Commands as PdfViewCommands,
   } from './fabric/RNPDFPdfNativeComponent';
 import ReactNativeBlobUtil from 'react-native-blob-util'
-import {ViewPropTypes} from 'deprecated-react-native-prop-types';
 const SHA1 = require('crypto-js/sha1');
-import PdfView from './PdfView';
+
+let PdfView;
+
+const getPdfView = () => {
+    if (!PdfView) {
+        const module = require('./PdfView');
+        PdfView = module.default || module;
+    }
+
+    return PdfView;
+};
 
 export default class Pdf extends Component {
 
     static propTypes = {
-        ...ViewPropTypes,
         source: PropTypes.oneOfType([
             PropTypes.shape({
                 uri: PropTypes.string,
@@ -454,17 +462,17 @@ export default class Pdf extends Component {
                                                     path={this.state.path}
                                                     onChange={this._onChange}
                                                 />
-                                            ):(<PdfView
-                                                {...this.props}
-                                                style={[{backgroundColor: '#EEE',overflow: 'hidden'}, this.props.style]}
-                                                path={this.state.path}
-                                                onLoadComplete={this.props.onLoadComplete}
-                                                onPageChanged={this.props.onPageChanged}
-                                                onError={this._onError}
-                                                onPageSingleTap={this.props.onPageSingleTap}
-                                                onScaleChanged={this.props.onScaleChanged}
-                                                onPressLink={this.props.onPressLink}
-                                            />)
+                                            ):(React.createElement(getPdfView(), {
+                                                ...this.props,
+                                                style: [{backgroundColor: '#EEE',overflow: 'hidden'}, this.props.style],
+                                                path: this.state.path,
+                                                onLoadComplete: this.props.onLoadComplete,
+                                                onPageChanged: this.props.onPageChanged,
+                                                onError: this._onError,
+                                                onPageSingleTap: this.props.onPageSingleTap,
+                                                onScaleChanged: this.props.onScaleChanged,
+                                                onPressLink: this.props.onPressLink,
+                                            }))
                                     )
                                 )}
                     </View>);


### PR DESCRIPTION
## Summary

Fixes a New Architecture/Fabric runtime import issue by keeping the Fabric/native component as the default path and avoiding evaluation of the legacy fallback module during package import.

In Expo SDK 56 / RN 0.85, native codegen and `RNPDFPdfView` registration work, but `index.js` still eagerly imports the legacy `PdfView` fallback. That can make the package fail during JS module initialization before Fabric renders.

This change lazy-loads the legacy fallback only if that branch is actually reached. The default Fabric path is unchanged.

## Related

Related to #942, #986, and the iOS Fabric work in #927. Also follows recent New Architecture/Fabric fixes in #1011 and #1012, and may overlap with #968.

cc @wonday @Prajwaltechversant @francoangulo @yfuks @mavrickdeveloper @huydosgtech @maribeiroleya

## Testing

- `node --check index.js`
- Verified the same patch in an Expo SDK 56 / RN 0.85 New Architecture app: iOS builds, launches, and the PDF viewer opens without the module import failure.

Can this be merged and released as a patch version, e.g. `7.0.5`?
