### PR TITLE
fix(ios): return NO from PdfManager requiresMainQueueSetup (#1021)

### DIFF
--- a/ios/RNPDFPdf/PdfManager.mm
+++ b/ios/RNPDFPdf/PdfManager.mm
@@ -128,7 +128,7 @@ RCT_EXPORT_METHOD(loadFile:(NSString *)path
 
 + (BOOL)requiresMainQueueSetup
 {
-    return YES;
+    return NO;
 }
 
 


### PR DESCRIPTION
Closes #1021

## 🐛 What was the issue?
`PdfManager` in `ios/RNPDFPdf/PdfManager.mm` returned `YES` from `+requiresMainQueueSetup`, despite having an empty `init` method that performs no UIKit or main-thread initialization work. 
Returning `YES` unnecessarily forces React Native bridge setup for `PdfManager` onto the main thread via `dispatch_sync`, which can cause performance bottlenecks and rare app hang issues on iOS during app startup.

## 🛠️ What did we fix?
- Changed `+requiresMainQueueSetup` in `ios/RNPDFPdf/PdfManager.mm` to return `NO`.
- Kept view manager setup (`RNPDFPdfViewManager.mm`, `RNPDFPdfPageViewManager.mm`) unchanged as view managers construct UI components on the main thread.

## 🧪 Testing & Verification
- Verified that `PdfManager` does not execute any UIKit or UI calls in `init` or module setup.
- Verified that returning `NO` allows React Native to initialize `PdfManager` off the main queue safely without blocking bridge setup.
