### PR TITLE
fix(android): restore zoom and scroll offset when the view is re-attached to the window

### DIFF
--- a/android/src/main/java/org/wonday/pdf/PdfView.java
+++ b/android/src/main/java/org/wonday/pdf/PdfView.java
@@ -90,6 +90,15 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
     private float lastPageWidth = 0;
     private float lastPageHeight = 0;
 
+    // Viewport snapshot taken in onDetachedFromWindow so the reload triggered by
+    // onAttachedToWindow can restore zoom and scroll offset (restorePath doubles
+    // as the "snapshot valid" flag and guards against the source changing between
+    // detach and re-attach).
+    private String restorePath = null;
+    private float restoreZoom = 1;
+    private float restoreXOffset = 0;
+    private float restoreYOffset = 0;
+
     // used to store the parameters for `super.onSizeChanged`
     private int oldW = 0;
     private int oldH = 0;
@@ -155,6 +164,22 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
         float height = pageSize.getHeight();
 
         this.zoomTo(this.scale);
+
+        // Restore the viewport saved in onDetachedFromWindow. The base class jumps
+        // to defaultPage right after this callback returns, so the restore must be
+        // posted to run after that jump or it would be overwritten.
+        if (this.restorePath != null && this.restorePath.equals(this.path)) {
+            final float zoom = this.restoreZoom;
+            final float xOffset = this.restoreXOffset;
+            final float yOffset = this.restoreYOffset;
+            this.restorePath = null;
+            this.post(() -> {
+                this.zoomTo(zoom);
+                this.moveTo(xOffset, yOffset);
+                this.loadPages();
+            });
+        }
+
         WritableMap event = Arguments.createMap();
 
         //create a new json Object for the TableOfContents
@@ -287,6 +312,21 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
         super.onAttachedToWindow();
         if (this.isRecycled())
             this.drawPdf();
+    }
+
+    // The base PDFView recycles the document (zoom, offset, render state) whenever
+    // the view leaves the window — e.g. while another screen is stacked over this
+    // one on Android. Snapshot the viewport before that happens; loadComplete
+    // restores it after the re-attach reload.
+    @Override
+    protected void onDetachedFromWindow() {
+        if (!this.isRecycled() && this.path != null) {
+            this.restorePath = this.path;
+            this.restoreZoom = this.getZoom();
+            this.restoreXOffset = this.getCurrentXOffset();
+            this.restoreYOffset = this.getCurrentYOffset();
+        }
+        super.onDetachedFromWindow();
     }
 
     private int getPdfPageCount(File pdfFile) throws IOException {


### PR DESCRIPTION
## Problem

On Android, the base `PDFView` calls `recycle()` in `onDetachedFromWindow`, which resets `zoom`, `currentXOffset`, and `currentYOffset`. `PdfView.onAttachedToWindow` then reloads the document via `drawPdf()`, which lands at the top of `defaultPage`.

So whenever the view is detached from the window **without being unmounted** — a react-navigation / react-native-screens screen pushed on top, a bottom-tab switch, a device rotation — the user loses their reading position and pinch zoom when they return to the PDF.

This is a long-standing pain point: #224, #275, #329, #380 all describe variants of it.

## Fix

- `onDetachedFromWindow` (new override): snapshot `getZoom()`, `getCurrentXOffset()`, `getCurrentYOffset()` and the current `path` **before** calling `super`, where the base class recycles. Only taken when the view isn't already recycled.
- `loadComplete`: if a snapshot exists and the `path` is unchanged, restore the viewport (`zoomTo` → `moveTo` → `loadPages()`).

The restore is `post()`-ed deliberately: the base class's internal `loadComplete` invokes the `onLoad` callback **before** `jumpTo(defaultPage)`, so a synchronous restore would be immediately overwritten by that jump.

The path guard means a source change between detach and re-attach behaves exactly as before (fresh load, no restore). No API change, no new props; iOS is unaffected.

## Testing

Tested in a production cruise-line app (React Native 0.86, new architecture/Fabric, expo-router with react-native-screens native stack) on Android: with this change, scroll position and pinch zoom survive another screen being stacked over the PDF viewer and closed again — previously the document reloaded at the top of the last page with zoom reset. By the same mechanism this should also cover the tab-switch and rotation reports in the linked issues.