### PR TITLE
fix(download): restore missing fetch() call dropped in #1019/#1020 merge

### DIFF
--- a/index.js
+++ b/index.js
@@ -268,46 +268,62 @@ export default class Pdf extends Component {
         }
 
         const tempCacheFile = cacheFile + '.tmp';
-        // Await the unlink: the previous fire-and-forget call let ReactNativeBlobUtil's
+        // Await the unlink: a fire-and-forget call here lets ReactNativeBlobUtil's
         // open(path) race with the in-flight delete on Android 14 + New Architecture and
         // surface as `ENOENT (No such file or directory)` on the temp file. See #1018.
         await this._unlinkFile(tempCacheFile);
 
-                this.lastRNBFTask = null;
-                const responseInfo = res ? res.respInfo : undefined;
+        try {
+            this.lastRNBFTask = ReactNativeBlobUtil.config({
+                // response data will be saved to this path if it has access right.
+                path: tempCacheFile,
+                trusty: this.props.trustAllCerts,
+            })
+                .fetch(
+                    source.method ? source.method : 'GET',
+                    source.uri,
+                    source.headers ? source.headers : {},
+                    source.body ? source.body : ""
+                )
+                // listen to download progress event
+                .progress((received, total) => {
+                    this.props.onLoadProgress && this.props.onLoadProgress(received / total);
+                    if (this._mounted) {
+                        this.setState({progress: received / total});
+                    }
+                });
 
-                if (responseInfo && typeof responseInfo.status === "number" && (responseInfo.status < 200 || responseInfo.status >= 300)) {
-                    throw this._createDownloadError(source.uri, responseInfo);
-                }
+            const res = await this.lastRNBFTask;
+            this.lastRNBFTask = null;
+            const responseInfo = res ? res.respInfo : undefined;
 
-                if (responseInfo && responseInfo.headers && !responseInfo.headers["Content-Encoding"] && !responseInfo.headers["Transfer-Encoding"] && responseInfo.headers["Content-Length"]) {
-                    const expectedContentLength = responseInfo.headers["Content-Length"];
-                    let actualContentLength;
+            if (responseInfo && typeof responseInfo.status === "number" && (responseInfo.status < 200 || responseInfo.status >= 300)) {
+                throw this._createDownloadError(source.uri, responseInfo);
+            }
 
-            if (res && res.respInfo && res.respInfo.headers && !res.respInfo.headers["Content-Encoding"] && !res.respInfo.headers["Transfer-Encoding"] && res.respInfo.headers["Content-Length"]) {
-                const expectedContentLength = res.respInfo.headers["Content-Length"];
+            if (responseInfo && responseInfo.headers && !responseInfo.headers["Content-Encoding"] && !responseInfo.headers["Transfer-Encoding"] && responseInfo.headers["Content-Length"]) {
+                const expectedContentLength = responseInfo.headers["Content-Length"];
                 let actualContentLength;
 
                 try {
                     const fileStats = await ReactNativeBlobUtil.fs.stat(res.path());
 
-                        actualContentLength = fileStats.size;
-                    } catch (error) {
+                    if (!fileStats || !fileStats.size) {
                         throw this._createDownloadError(source.uri, responseInfo);
                     }
 
-                    if (expectedContentLength != actualContentLength) {
-                        throw this._createDownloadError(source.uri, responseInfo);
-                    }
+                    actualContentLength = fileStats.size;
+                } catch (error) {
+                    throw this._createDownloadError(source.uri, responseInfo);
                 }
 
                 if (expectedContentLength != actualContentLength) {
-                    throw new Error("DownloadFailed:" + source.uri);
+                    throw this._createDownloadError(source.uri, responseInfo);
                 }
             }
 
             await this._unlinkFile(cacheFile);
-            // Await the copy: the previous fire-and-forget chain swallowed cp() rejections
+            // Await the copy: a fire-and-forget chain here swallows cp() rejections
             // as `Uncaught (in promise)` instead of forwarding them through onError.
             await ReactNativeBlobUtil.fs.cp(tempCacheFile, cacheFile);
             if (this._mounted) {


### PR DESCRIPTION
Fixes #1030.

## Problem

`_downloadFile` on `master` throws `ReferenceError: res is not defined` on every download attempt — the `ReactNativeBlobUtil.config(...).fetch(...).progress(...)` call itself was dropped when #1019 merged on top of #1020 (see #1030 for the full history/diff analysis of how this happened). There's also no download at all possible right now since the function can't produce a response.

## Fix

- Restores the `ReactNativeBlobUtil.config({ path: tempCacheFile, trusty: this.props.trustAllCerts }).fetch(...).progress(...)` call, assigned to `this.lastRNBFTask` (preserving cancellation via `componentDidUpdate`/`componentWillUnmount`) and `await`-ed to get `res`.
- Keeps #1019's structure: a single `try`/`catch` around the whole download+copy flow, with `await`-ed `_unlinkFile`/`cp` calls so a failure can't escape as an unhandled rejection and can't be silently treated as a success (this also happens to fix a distinct real-world bug we hit against the last release, 7.0.4 — where a failed/truncated download from a `react-native-blob-util` 0.24.10 regression, [RonRadtke/react-native-blob-util#477](https://github.com/RonRadtke/react-native-blob-util/issues/477), was reported as `onError('cannot create document: File not in PDF format or corrupted.')` instead of the real `Download interrupted.`, because 7.0.4's `.then()` was chained after `.catch()` on the same promise and the caught rejection still resolved).
- Keeps #1020's `responseInfo`/`_createDownloadError` HTTP-status exposure.
- Removes the duplicated content-length validation block left over from the two diffs overlapping.

## Verified

- `node --check index.js` passes (previous `master` also passed check despite the `ReferenceError`, since that's a runtime error, not a syntax error — worth having a lightweight smoke test around `_downloadFile` to catch this class of bug in CI going forward, happy to help with that if useful).
- Manually traced the flow against a real Android device test case (an 801 KB PDF over S3) that previously hit both the blob-util truncation and the pdf.js corrupted-file symptom; with both fixes applied the file downloads and renders in full.