### PR TITLE
fix(ios): set long press recognizer delegate so PDFKit text selection can start

### DIFF
--- a/ios/RNPDFPdf/RNPDFPdfView.mm
+++ b/ios/RNPDFPdf/RNPDFPdfView.mm
@@ -910,6 +910,8 @@ using namespace facebook::react;
     longPressRecognizer.allowableMovement=100;
     // Important: The duration must be long enough to allow taps but not longer than the period in which view opens the magnifying glass
     longPressRecognizer.minimumPressDuration=0.3;
+    // Without a delegate this recognizer excludes PDFKit's own long press, which is what starts a text selection
+    longPressRecognizer.delegate = self;
 
     [self addGestureRecognizer:longPressRecognizer];
     _longPressRecognizer = longPressRecognizer;


### PR DESCRIPTION
## Summary

On iOS, text selection in `PDFView` never starts: long-press-and-drag on a text-layer PDF produces no selection, no magnifier, and no copy menu. This completes #1003 — that PR added the machinery to *report* a selection (`enableTextSelection` / `onTextSelectionChange`), but on iOS a selection could not be started in the first place.

One-line fix: give the long press recognizer created in `bindTap` a delegate.

## Root cause

`bindTap` attaches a `UILongPressGestureRecognizer` to the wrapper view (`self`, the `RNPDFPdfView`), targeting `handleLongPress:`. That handler has an empty body — its own doc comment says "Do nothing on long Press".

Unlike the tap and pinch recognizers created alongside it, this one sets no `delegate`:

```objc
UILongPressGestureRecognizer *longPressRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
                                                                                        action:@selector(handleLongPress:)];
// Making sure the allowable movement isn not too narrow
longPressRecognizer.allowableMovement=100;
// Important: The duration must be long enough to allow taps but not longer than the period in which view opens the magnifying glass
longPressRecognizer.minimumPressDuration=0.3;

[self addGestureRecognizer:longPressRecognizer];
```

With no delegate, `gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:` is never consulted and defaults to `NO`. Once this recognizer recognizes, it prevents PDFKit's own long press — the gesture that begins a text selection in `PDFView`. Its `minimumPressDuration = 0.3` is explicitly tuned to fire before the magnifier (see the existing comment), which is why it wins the race. Net effect: selection and copy never start.

## Fix

```objc
longPressRecognizer.delegate = self;
```

The class already implements both delegate methods and both return `!_singlePage`, which is the correct answer here:

```objc
- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
{
    return !_singlePage;
}

- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
{
    return !_singlePage;
}
```

So the recognizer keeps working for non-`singlePage` views, but it stops excluding PDFKit's.

I deliberately did **not** delete the recognizer. Its tuning comment suggests it guards against the magnifier appearing mid-pan, so the minimal change is to let both recognize rather than remove behavior that was added on purpose.

## Test plan

Verified on a physical iOS device in a host app, with this change applied to `react-native-pdf@7.0.4` via `patch-package`.

- Before: long-press-and-drag on a text-layer PDF — no selection, no magnifier, no copy menu.
- After: selection and copy work.

Environment:

- react-native-pdf 7.0.4
- React Native 0.81.5, Expo SDK 54
- New Architecture (Fabric) enabled
- iOS 26, physical device
- Test document: a text-layer PDF (embedded fonts, no scanned images), unencrypted, with no copy-permission restrictions

It reproduced regardless of `enablePaging` / `horizontal`, so it is not specific to the paged / `usePageViewController` path.

## Separate observation (not fixed here)

`enableTextSelection` is exported for the old architecture (`RCT_EXPORT_VIEW_PROPERTY(enableTextSelection, BOOL)` in `RNPDFPdfViewManager.mm`) but is missing from the codegen spec in `fabric/RNPDFPdfNativeComponent.js`, so under Fabric it never reaches native and `_enableTextSelection` stays at its initializer default of `YES` — meaning the prop cannot be turned off on the New Architecture. Happy to send that as a separate PR if wanted.
