### PR TITLE
fix(android): apply scale prop changes to the live PDFView

### DIFF
--- a/android/src/main/java/org/wonday/pdf/PdfView.java
+++ b/android/src/main/java/org/wonday/pdf/PdfView.java
@@ -434,6 +434,9 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
 
     public void setScale(float scale) {
         this.scale = scale;
+        if (!this.isRecycled()) {
+            this.zoomTo(this.scale);
+        }
     }
 
     public void setMinScale(float minScale) {


### PR DESCRIPTION
## Problem

On Android, updating the `scale` prop on an already-loaded PDF has no visible effect. `setScale()` only stores the new value on the field; it never calls `PDFView#zoomTo()`, so the view keeps rendering at whatever scale it had.

The scale *is* applied correctly on initial load, since `loadComplete()` separately calls `this.zoomTo(this.scale)`. Only prop *updates* after the first load are silently dropped.

## Fix

Call `zoomTo()` from `setScale()` as well, guarded by `isRecycled()` (same guard used elsewhere in this class) to avoid touching a view that's mid-teardown.

## Testing

Verified in our app (React Native, new architecture / Fabric) with a zoom-in/zoom-out toolbar driving the `scale` prop imperatively — before the fix the zoom level was frozen after first load; after the fix it updates live.