### PR TITLE
fix(ios): compare path prop by value, not pointer identity

### DIFF
--- a/ios/RNPDFPdf/RNPDFPdfView.mm
+++ b/ios/RNPDFPdf/RNPDFPdfView.mm
@@ -106,8 +106,9 @@ using namespace facebook::react;
 {
     const auto &newProps = *std::static_pointer_cast<const RNPDFPdfViewProps>(props);
     NSMutableArray<NSString *> *updatedPropNames = [NSMutableArray new];
-    if (_path != RCTNSStringFromStringNilIfEmpty(newProps.path)) {
-        _path = RCTNSStringFromStringNilIfEmpty(newProps.path);
+    NSString *newPath = RCTNSStringFromStringNilIfEmpty(newProps.path);
+    if (_path != newPath && ![_path isEqualToString:newPath]) {
+        _path = newPath;
         [updatedPropNames addObject:@"path"];
     }
     if (_page != newProps.page) {
@@ -379,8 +380,8 @@ using namespace facebook::react;
             } else {
             
                 // decode file path
-                _path = (__bridge_transfer NSString *)CFURLCreateStringByReplacingPercentEscapes(NULL, (CFStringRef)_path, CFSTR(""));
-                NSURL *fileURL = [NSURL fileURLWithPath:_path];
+                NSString *decodedPath = (__bridge_transfer NSString *)CFURLCreateStringByReplacingPercentEscapes(NULL, (CFStringRef)_path, CFSTR(""));
+                NSURL *fileURL = [NSURL fileURLWithPath:decodedPath];
                 _pdfDocument = [[PDFDocument alloc] initWithURL:fileURL];
             }
 


### PR DESCRIPTION
## Problem

`updateProps` decides whether the `path` prop changed with pointer identity (`!=`):

```objc
if (_path != RCTNSStringFromStringNilIfEmpty(newProps.path)) {
```

`RCTNSStringFromStringNilIfEmpty` allocates a fresh `NSString` on every call, so this condition is true on *every* props diff that includes `path`, even when the string content is identical to what's already loaded. Downstream, `didSetProps` treats `path` as changed and reloads the document — so any unrelated prop update (paging state, indicators, etc.) that happens to also carry `path` in the diff can trigger a spurious PDF reload.

## Fix

Compare by `isEqualToString:` after the pointer fast-path, same pattern used elsewhere in this file for string props.

While fixing this I found a related bug it was masking: the percent-decoding step in `didSetProps` overwrites `_path` in place —

```objc
_path = (__bridge_transfer NSString *)CFURLCreateStringByReplacingPercentEscapes(NULL, (CFStringRef)_path, CFSTR(""));
```

— so if that block runs twice with the same `_path` (which the spurious-reload bug above made likely), the second run feeds an already-decoded path back into `CFURLCreateStringByReplacingPercentEscapes`. Decoding into a local `decodedPath` variable instead avoids mutating the ivar.

## Testing

Verified in our app (React Native, new architecture / Fabric): before the fix, toggling an unrelated prop on the PDF view while `path` stayed the same still reloaded the document; after the fix it doesn't.