### PR TITLE
fix(ios): resolve Xcode compiler warnings

### DIFF
--- a/ios/RNPDFPdf/RNPDFPdfView.mm
+++ b/ios/RNPDFPdf/RNPDFPdfView.mm
@@ -235,7 +235,7 @@ using namespace facebook::react;
 
 - (void)setNativePage:(NSInteger)page
 {
-    _page = page;
+    _page = static_cast<int>(page);
     [self didSetProps:[NSArray arrayWithObject:@"page"]];
 }
 
@@ -762,7 +762,7 @@ using namespace facebook::react;
  *  Tap
  *  zoom reset or zoom in
  *
- *  @param recognizer
+ *  @param recognizer The double-tap gesture recognizer.
  */
 - (void)handleDoubleTap:(UITapGestureRecognizer *)recognizer
 {
@@ -835,7 +835,7 @@ using namespace facebook::react;
  *  Single Tap
  *  stop zoom
  *
- *  @param recognizer
+ *  @param sender The single-tap gesture recognizer.
  */
 - (void)handleSingleTap:(UITapGestureRecognizer *)sender
 {
@@ -859,7 +859,7 @@ using namespace facebook::react;
  *  Pinch
  *
  *
- *  @param recognizer
+ *  @param sender The pinch gesture recognizer.
  */
 -(void)handlePinch:(UIPinchGestureRecognizer *)sender{
     [self onScaleChanged:Nil];


### PR DESCRIPTION
## Summary

- Add non-empty descriptions to the gesture-handler `@param` documentation.
- Make the documented parameter names match the actual `sender` parameters.
- Explicitly convert the Fabric command's `NSInteger` page argument to the component's `int` storage type.

## Problem

Xcode reports documentation warnings for empty or mismatched `@param` entries, plus an implicit 64-bit-to-32-bit conversion warning in `setNativePage:`.

## Fix

The comments now document the correct parameters, and the page assignment uses an explicit `static_cast<int>`. The Fabric command is declared as `Int32`, so the conversion matches the command's existing type contract while making the native boundary explicit.

## Testing

Compiled `RNPDFPdfView.mm` with Apple Clang from Xcode 26.6 using the CocoaPods-generated response file, React Native Fabric headers, iOS Simulator 26.5 SDK, and the target's warning settings (including documentation and 64-to-32-bit conversion warnings). The compile completed with no diagnostics.

Closes #1023.
