### PR TITLE
fix(android): preserve encoded content URIs

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,6 +255,7 @@ export default class Pdf extends Component {
                 const isNetwork = !!(uri && uri.match(/^https?:\/\//));
                 const isAsset = !!(uri && uri.match(/^bundle-assets:\/\//));
                 const isBase64 = !!(uri && uri.match(/^data:application\/pdf;base64/));
+                const isContentUri = !!(uri && uri.match(/^content:\/\//i));
 
                 const filename = source.cacheFileName || SHA1(uri) + '.pdf';
                 const cacheFile = ReactNativeBlobUtil.fs.dirs.CacheDir + '/' + filename;
@@ -291,7 +292,11 @@ export default class Pdf extends Component {
                         });
                 } else {
                     if (this._mounted) {
-                      const localPath = decodeURIComponent(uri.replace(/file:\/\//i, ''));
+                      // Android grants scoped access to the exact content URI. Decoding
+                      // it changes the permission key (for example, %3A becomes :).
+                      const localPath = isContentUri
+                          ? uri
+                          : decodeURIComponent(uri.replace(/file:\/\//i, ''));
                       if (this.props.transformFile) {
                           try {
                               const viewFile = await this._transformToViewFile(localPath);


### PR DESCRIPTION
## Summary

- Preserve Android `content://` source URIs exactly as received.
- Continue decoding `file://` and other local paths, retaining support for encoded spaces and accented filenames.

## Problem

Android scoped URI permissions are keyed by the exact URI. The current local-source path runs every URI through `decodeURIComponent`, so a granted URI such as:

```
content://com.android.providers.downloads.documents/document/msf%3A6179
```

becomes `.../msf:6179` before it reaches `ContentResolver`. That no longer matches the temporary permission granted by Android.

## Fix

Detect `content://` sources before normalizing the local path and pass those URIs through unchanged. All non-content local sources keep the existing decoding behavior, including the accented-filename fix from #873.

## Testing

- Focused Jest regression check against `Pdf#_prepareFile`:
  - `content://.../msf%3A6179` remains byte-for-byte unchanged.
  - `file:///documents/R%C3%A9sum%C3%A9%20final.pdf` still becomes `/documents/Résumé final.pdf`.
- `node --check index.js`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts`

Closes #990.
